### PR TITLE
Fix empty link text for 0055 index page

### DIFF
--- a/articles/0055/_posts/2017-03-26-0055-index.md
+++ b/articles/0055/_posts/2017-03-26-0055-index.md
@@ -21,25 +21,25 @@ tags: 0055 index
 
 Ruby をはじめるにあたって必要な情報をご紹介します。本稿は Rubyist Magazine 常設記事です。(難易度：低)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) []({{base}}{% post_url articles/0055/2017-03-26-0055-pycall %})
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [PyCall があれば Ruby で機械学習ができる]({{base}}{% post_url articles/0055/2017-03-26-0055-pycall %})
 
 書いた人：@mrkn さん
 
 PyCall と呼ばれる Ruby-Python ブリッジライブラリの紹介記事です。(難易度：高。丁寧な現状分析と問題解決に挑むスピード感がすごい。)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) []({{base}}{% post_url articles/0055/2017-03-26-0055-RubyKaigi2016Nursery %})
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyKaigi 2016 託児室運営記録（技術カンファレンスにおける託児サービス提供について）]({{base}}{% post_url articles/0055/2017-03-26-0055-RubyKaigi2016Nursery %})
 
 書いた人：鳥井雪さん
 
 RubyKaigi 2016 で開設した託児所の運営記録です。(難易度：子供を預かるのは大変)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) []({{base}}{% post_url articles/0055/2017-03-26-0055-RubyConf2016Report %})
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyConf 2016 参加レポート]({{base}}{% post_url articles/0055/2017-03-26-0055-RubyConf2016Report %})
 
 書いた人：@mtsmfm さん
 
 2016 年 11 月に開催された RubyConf 2016 の参加レポート記事です。(難易度：中。3 日間の圧倒的なボリューム)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) []({{base}}{% post_url articles/0055/2017-03-26-0055-KawasakiRubyKaigi01Report %})
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RegionalRubyKaigi レポート (60) 川崎 Ruby 会議 01]({{base}}{% post_url articles/0055/2017-03-26-0055-KawasakiRubyKaigi01Report %})
 
 書いた人：@snowcrush さん、近藤さん
 


### PR DESCRIPTION
55 号の index でリンクのテキストが抜けてるのを発見したので直してみました