### PR TITLE
Fix a problem that double lines in syntax highlight area

### DIFF
--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,7 +1,7 @@
 /* This css file is the colorful.css theme from https://github.com/iwootten/jekyll-syntax */
 
 .highlight .hll { background-color: #ffffcc }
-.highlight  {
+pre.highlight, figure.highlight {
   background: #ffffff;
   border-style: solid;
   border-width: 1px;

--- a/docs/css/syntax.css
+++ b/docs/css/syntax.css
@@ -1,7 +1,7 @@
 /* This css file is the colorful.css theme from https://github.com/iwootten/jekyll-syntax */
 
 .highlight .hll { background-color: #ffffcc }
-.highlight  {
+pre.highlight, figure.highlight {
   background: #ffffff;
   border-style: solid;
   border-width: 1px;


### PR DESCRIPTION
コードブロックの部分にて、罫線が二重に引かれる問題を修正しました。

58号リリースと同時にリリースしたい。
