### PR TITLE
Fix link to TryRuby

### DIFF
--- a/articles/first_step_ruby/_posts/2000-01-01-FirstStepRuby.md
+++ b/articles/first_step_ruby/_posts/2000-01-01-FirstStepRuby.md
@@ -31,7 +31,7 @@ tags: FirstStepRuby
 
 まずは Ruby でプログラムが書ける環境を整えましょう。
 
-インストールする前にちょっと Ruby を味見してみたいと言う方は [TryRuby](http://tryruby.org) を試してみると良いかもしれません。
+インストールする前にちょっと Ruby を味見してみたいと言う方は [TryRuby](https://ruby.github.io/TryRuby/) を試してみると良いかもしれません。
 
 ### Ruby の種類について
 


### PR DESCRIPTION
tryruby.org(Try Ruby version 2 )はもう無くなってしまったらしいです。
参考： https://github.com/Sophrinix/TryRuby#tryruby-version-2-obsolete

代わりに、現在まだ使用可能な https://ruby.github.io/TryRuby/ (Try Ruby version 4) へリンクするようにしました。
参考： https://github.com/easydatawarehousing/tryruby