### PR TITLE
Add RejectKaigi 2019 article for RubyKaigi 2019 

### DIFF
--- a/articles/preRubyKaigi2019/_posts/2019-03-18-preRubyKaigi2019-index.md
+++ b/articles/preRubyKaigi2019/_posts/2019-03-18-preRubyKaigi2019-index.md
@@ -60,6 +60,10 @@ RubyKaigi 2019 に向けて多くの企業や参加者、 Rubyist 、福岡出�
 
 株式会社SpeeeさまによるCoffee Sponsorの紹介と、コード懇親会、After Hack、RejectKaigiの案内です。
 
+### [RejectKaigi 2019 を開催します]({{base}}{% post_url articles/preRubyKaigi2019/2019-03-18-preRubyKaigi2019-reject-kaigi-2019-index %})
+
+2019年4月12日（金）にピクシブ株式会社とGMOペパボ株式会社の福岡オフィスにてRejectKaigi 2019を開催します。
+
 ### 書いた人
 
 * RubyKaigi 2018 Speaker から : Speakerのみなさん

--- a/articles/preRubyKaigi2019/_posts/2019-03-18-preRubyKaigi2019-reject-kaigi-2019-index.md
+++ b/articles/preRubyKaigi2019/_posts/2019-03-18-preRubyKaigi2019-reject-kaigi-2019-index.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: RejectKaigi 2019 のお知らせ
+short_title: RejectKaigi 2019
+tags: preRubyKaigi2019
+post_author: alitaso346
+created_on: 2019/03/29
+updated_on: 2019/03/29
+---
+{% include base.html %}
+
+## Reject Kaigiとは
+RubyKaigi 2019のCFP提出者で、惜しくもAcceptの機会を逃された方（つまりRejectされた人）をメインに、ご登壇者としてRubyに関する発表をしていただくイベントです。
+このイベントは、より多くのRubyistに自身の取り組みや成果を発表できる機会を創出し、Rubyコミュニティの発展および4月開催のRubyKaigi 2019をさらに盛り上げることを目的とした【RubyKaigi 2019公式イベント】です。
+
+RubyKaigiの本編に行かれない方も本イベントには参加可能です。雰囲気を知りたい方などもぜひお越しください。
+
+## イベント概要
+2019年4月12日（金）にピクシブ株式会社とGMOペパボ株式会社の福岡オフィスにてRejectKaigi 2019を開催します。
+東京会場と福岡会場の2つを用意し相互中継を行いますので、福岡在住の方も登壇可能です。
+
+下記のようなコンテンツを用意しています。
+
+- 各20分枠のRubyに関する発表
+- 松田明氏＆ RubyKaigi運営チームによるRubyKaigi 2019タイムテーブル徹底解説
+
+20分枠での登壇希望の方は[こちらのフォーム](https://goo.gl/forms/V2rJnL47vad4XDSg2)からお申込みください。
+
+また20分枠の発表に加え、RubyKaigiのLT枠にRejectされた方を主な対象としてLT枠も用意予定です。
+LT枠は現在調整中ですので、詳細は追ってお伝えいたします。
+
+
+## 参加登録
+以下のconnpassから登録をお願いします。
+参加締め切りは4月12日(金)となっております。
+東京会場はすでに参加希望者の抽選が行われましたが補欠枠でお申込みいただけます。
+また福岡会場は残席がございますので、そちらもお気軽にお申し込みください。
+
+東京会場用connpass：[https://pixiv.connpass.com/event/124727/](https://pixiv.connpass.com/event/124727/)
+
+福岡会場用connpass：[https://fukuokarb.connpass.com/event/124966/](https://fukuokarb.connpass.com/event/124966/)
+
+みなさまの参加をお待ちしております！


### PR DESCRIPTION
関連issue https://github.com/rubima/magazine.rubyist.net/issues/137

はじめまして。RejectKaigi 2019運営のalitasoです。
RejectKaigi 2019の概要を特集号に載せていただければと思い、プレ記事に追加させてもらいました。

るびまへの寄稿がはじめてでして、要修正の部分がありましたらツッコミお願いします。