### PR TITLE
update reject kaigi 2019 timetable

### DIFF
--- a/articles/preRubyKaigi2019/_posts/2019-03-18-preRubyKaigi2019-reject-kaigi-2019-index.md
+++ b/articles/preRubyKaigi2019/_posts/2019-03-18-preRubyKaigi2019-reject-kaigi-2019-index.md
@@ -25,12 +25,31 @@ RubyKaigiの本編に行かれない方も本イベントには参加可能で�
 - 松田明氏＆ RubyKaigi運営チームによるRubyKaigi 2019タイムテーブル徹底解説
 - 各5分枠のRubyに関するLT
 
+| 時間 | 内容 | 発表者 |
+|-----|------|-------|
+| 19:00 | 開場 | - |
+| 19:35 | 開会の挨拶 | [@a_matsuda](https://twitter.com/a_matsuda) |
+| 19:40 | OCI-compatible haconiwa ─ hurdles and advantages ─ もしくはOCI interefaceを持つRuby processについて | [@yu_suke1994](https://twitter.com/yu_suke1994) |
+| 20:05 | Agyoh and Umgyo Assume Controll of a Mobile Device | [@jimlock](https://twitter.com/jimlock) |
+| 20:30 | 休憩| - |
+| 20:40 | RubyKaigi 2019タイムテーブル徹底解説 | [@a_matsuda](https://twitter.com/a_matsuda) & RubyKaigi運営チーム |
+| 21:25 | 懇親会およびLT | - |
+| 21:30 | mruby with Visual Programming App -Springin' + mruby- | [@kskktk](https://twitter.com/kskktk) |
+| 21:35 | Rails 6 MySQLのutf8mb4対応とは何であって何ではないのか | [@yahonda](https://twitter.com/yahonda) |
+| 21:40 | EnumerableをRubyで再実装してみる | [@okuramasafumi](https://twitter.com/okuramasafumi) |
+| 21:45 | just_all_the_same': A gem accelerate Array#all? inquiry | [@uproad3](https://twitter.com/uproad3) |
+| 21:50 | JavaScript-Free Soft-Realtime Browsing | [@niku_name](https://twitter.com/niku_name) |
+| 21:55 | Ruby on AWS Lambda | [@sh_ngsw](https://twitter.com/sh_ngsw) |
+| 22:25 | 懇親会終了/閉会の挨拶 | [@udzura](https://twitter.com/udzura) |
+| 22:30 | 撤収 | - |
+
 ~~20分枠での登壇希望の方はこちらのフォームからお申込みください。~~
 
 20分枠の申込みは締め切りました。ご応募ありがとうございました。
 
-現在5分LT枠の登壇者を募集中です。登壇希望の方は[こちらのフォーム](https://forms.gle/np1qpkNRNQMDTzrq5)からお申し込みください。Rubyに関する発表内容であれば、RubyKaigi本編のLTに申し込んだ方以外でもお申込みいただけます。申込み締め切りは4月8日(月)12:00の予定です。
+~~現在5分LT枠の登壇者を募集中です。登壇希望の方はこちらのフォームからお申し込みください。Rubyに関する発表内容であれば、RubyKaigi本編のLTに申し込んだ方以外でもお申込みいただけます。申込み締め切りは4月8日(月)12:00の予定です。~~
 
+5分LT枠の申込みは締め切りました。ご応募ありがとうございました。
 
 ## 参加登録
 以下のconnpassから登録をお願いします。


### PR DESCRIPTION
関連Issue https://github.com/rubima/magazine.rubyist.net/issues/137

RejectKaigiの5分LT枠の申込みを締め切りました。
また登壇者のタイムテーブルが決まりましたので更新しました。