### PR TITLE
各有益情報にスポンサー情報として、株式会社エムスリーのブース情報記事の紹介を追加しました。

### DIFF
--- a/articles/preRubyKaigi2019/_posts/2019-03-18-preRubyKaigi2019-index.md
+++ b/articles/preRubyKaigi2019/_posts/2019-03-18-preRubyKaigi2019-index.md
@@ -64,6 +64,10 @@ RubyKaigi 2019 に向けて多くの企業や参加者、 Rubyist 、福岡出�
 
 2019年4月12日（金）にピクシブ株式会社とGMOペパボ株式会社の福岡オフィスにてRejectKaigi 2019を開催します。
 
+### [エムスリーは「RubyKaigi 2019」にプラチナスポンサーとして協賛 & ブース出展します](https://www.m3tech.blog/entry/rubykaigi2019)
+
+株式会社エムスリーのブース出展情報です。ノベルティや参加者について記載されてます。
+
 ### 書いた人
 
 * RubyKaigi 2019 Speaker から : Speakerのみなさん


### PR DESCRIPTION
#137 に従い、
RubyKaigi2019のプレ記事にエムスリー分の情報を追記しました。