### PR TITLE
Fix rk2006 image path

### DIFF
--- a/articles/RubyKaigi2006/_posts/2006-06-28-RubyKaigi2006-index.md
+++ b/articles/RubyKaigi2006/_posts/2006-06-28-RubyKaigi2006-index.md
@@ -6,7 +6,7 @@ tags: rubykaigi2006 index
 ---
 {% include base.html %}
 
-![boom1-2-3.png]({{base}}{{site.baseurl}}/images/rubykaigi2006/boom1-2-3.png)
+![boom1-2-3.png]({{base}}{{site.baseurl}}/images/RubyKaigi2006/boom1-2-3.png)
 
 ## はじめに
 
@@ -49,7 +49,7 @@ tags: rubykaigi2006 index
 初日 ([プログラム](http://jp.rubyist.net/RubyKaigi2006/program0610.html)) のレポートです。
 
 ### 懇親会
-![s06100088.jpg]({{base}}{{site.baseurl}}/images/rubykaigi2006/s06100088.jpg)
+![s06100088.jpg]({{base}}{{site.baseurl}}/images/RubyKaigi2006/s06100088.jpg)
 
 日本科学未来館にて懇親会を行いました。
 

--- a/docs/articles/rubykaigi2006/RubyKaigi2006-index.html
+++ b/docs/articles/rubykaigi2006/RubyKaigi2006-index.html
@@ -210,7 +210,7 @@
 
                         </div>
                         
-<p><img src="../../images/rubykaigi2006/boom1-2-3.png" alt="boom1-2-3.png" /></p>
+<p><img src="../../images/RubyKaigi2006/boom1-2-3.png" alt="boom1-2-3.png" /></p>
 
 <h2 id="はじめに">はじめに</h2>
 
@@ -247,7 +247,7 @@
 <p>初日 (<a href="http://jp.rubyist.net/RubyKaigi2006/program0610.html">プログラム</a>) のレポートです。</p>
 
 <h3 id="懇親会">懇親会</h3>
-<p><img src="../../images/rubykaigi2006/s06100088.jpg" alt="s06100088.jpg" /></p>
+<p><img src="../../images/RubyKaigi2006/s06100088.jpg" alt="s06100088.jpg" /></p>
 
 <p>日本科学未来館にて懇親会を行いました。</p>
 


### PR DESCRIPTION
RubyKaigi 2006のトップページにおける画像ファイルがgithub pagesの場合参照できない問題を修正。