### PR TITLE
Rubyist Hotlinks 【第 8 回】インタビュー本文へのリンクを追加

### DIFF
--- a/articles/0008/_posts/2005-07-19-0008-Hotlinks.md
+++ b/articles/0008/_posts/2005-07-19-0008-Hotlinks.md
@@ -45,20 +45,9 @@ tags: 0008 Hotlinks
 
 ### 目次
 
-
-* Table of content
-{:toc}
-
-
-
-* Table of content
-{:toc}
-
-
-
-* Table of content
-{:toc}
-
+* [その1]({{base}}{% post_url articles/0008/2005-07-19-0008-Hotlinks-1 %})
+* [その2]({{base}}{% post_url articles/0008/2005-07-19-0008-Hotlinks-2 %})
+* [その3]({{base}}{% post_url articles/0008/2005-07-19-0008-Hotlinks-3 %})
 
 今回は長いのでページを分割しています (3ページ)。インタビュー本文は上記リンクをたどってください。
 


### PR DESCRIPTION
issue https://github.com/rubima/magazine.rubyist.net/issues/248 の修正です。

リンク切れではなくてそもそもリンクがなかったので追加しました。