### PR TITLE
Fix typo on 値渡しと参照渡しの違いを理解する

### DIFF
--- a/articles/0032/_posts/2011-01-31-0032-CallByValueAndCallByReference.md
+++ b/articles/0032/_posts/2011-01-31-0032-CallByValueAndCallByReference.md
@@ -182,7 +182,7 @@ def bar(arr)
 end
 
 numbers = [10, 20]
-bar(number)
+bar(numbers)
 puts numbers      #=> [11, 20]   # 中身が変更されている!
 {% endraw %}
 {% endhighlight %}


### PR DESCRIPTION
## Summary
変数名のtypo を修正しました。

cf. https://magazine.rubyist.net/articles/0032/0032-CallByValueAndCallByReference.html