### PR TITLE
Add symlink for missing matz image for legworks

### DIFF
--- a/images/0009-Legwork/elephant_at_hokudai.jpg
+++ b/images/0009-Legwork/elephant_at_hokudai.jpg
@@ -1,0 +1,1 @@
+../0008-Legwork/elephant_at_hokudai.jpg

--- a/images/0010-Legwork/elephant_at_hokudai.jpg
+++ b/images/0010-Legwork/elephant_at_hokudai.jpg
@@ -1,0 +1,1 @@
+../0008-Legwork/elephant_at_hokudai.jpg

--- a/images/0013-Legwork/matz_in_suit.jpg
+++ b/images/0013-Legwork/matz_in_suit.jpg
@@ -1,0 +1,1 @@
+../0011-Legwork/matz_in_suit.jpg

--- a/images/0014-Legwork/matz_in_suit.jpg
+++ b/images/0014-Legwork/matz_in_suit.jpg
@@ -1,0 +1,1 @@
+../0011-Legwork/matz_in_suit.jpg

--- a/images/0015-Legwork/matz_in_suit.jpg
+++ b/images/0015-Legwork/matz_in_suit.jpg
@@ -1,0 +1,1 @@
+../0011-Legwork/matz_in_suit.jpg

--- a/images/0017-Legwork/matz_in_suit.jpg
+++ b/images/0017-Legwork/matz_in_suit.jpg
@@ -1,0 +1,1 @@
+../0011-Legwork/matz_in_suit.jpg

--- a/images/0019-Legwork/matz.jpg
+++ b/images/0019-Legwork/matz.jpg
@@ -1,0 +1,1 @@
+../0018-Legwork/matz.jpg

--- a/images/0021-Legwork/matz.jpg
+++ b/images/0021-Legwork/matz.jpg
@@ -1,0 +1,1 @@
+../0018-Legwork/matz.jpg

--- a/images/0022-Legwork/matz.jpg
+++ b/images/0022-Legwork/matz.jpg
@@ -1,0 +1,1 @@
+../0018-Legwork/matz.jpg


### PR DESCRIPTION
「Rubyist のための他言語探訪」でmatzの画像がリンク切れになっているのを修正します。


# Problem


「Rubyist のための他言語探訪」の一部のページでmatzの画像がリンク切れになっていました。
それぞれリンク切れかどうかと、リンク先のsrcは次のようになっています。

|回  |リンク切れかどうか                    |src   |
|---|-----------------------------|------|
|第 1 回 Python| ok                          | `../../images/0008-Legwork/elephant_at_hokudai.jpg`|
|第 2 回 CLU| リンク切れ                       | `../../images/0009-Legwork/elephant_at_hokudai.jpg`|
|第 3 回 Io| リンク切れ                       | `../../images/0010-Legwork/elephant_at_hokudai.jpg`|
|第 4 回 Tcl| ok                          | `../../images/0011-Legwork/matz_in_suit.jpg`|
|第 5 回 Groovy| アイコンなし                      | ---  |
|第 6 回 Dylan| リンク切れ                       | `../../images/0013-Legwork/matz_in_suit.jpg`|
|第 7 回 Icon| リンク切れ                       | `../../images/0014-Legwork/matz_in_suit.jpg`|
|第 8 回 Forth| リンク切れ                       | `../../images/0015-Legwork/matz_in_suit.jpg`|
|第 9 回 日本語プログラミング言語「なでしこ」| ok                          | matz以外の著者の画像|
|第 10 回 Erlang| リンク切れ                       | `../../images/0017-Legwork/matz_in_suit.jpg`|
|第 11 回 C++| ok                          | `../../images/0018-Legwork/matz.jpg`|
|第 12 回 APL と J| リンク切れ                       | `../../images/0019-Legwork/matz.jpg`|
|第 13 回 Prolog| リンク切れ                       | `../../images/0021-Legwork/matz.jpg`|
|第 14 回 Whitespace| リンク切れ                       | `../../images/0022-Legwork/matz.jpg`|


そして、どうやらこの結果を見ると、「同じ画像が続く時、その画像の初回登場以外」でリンク切れになっているようです。
たとえば第1回 Pythonの画像は`elephant_at_hokudai.jpg`ですが、これと同じ画像が出てくる第2回 CLU ではリンク切れになっています。
そして、画像が`matz_in_suit.jpg`に変わった第4回 Tclでは画像が復活していますが、その次に同じ画像が使われている第6回ではまたリンク切れになっています。



なお、軽くgitのログを見てみたところ、このリポジトリの最初のコミットの時点から、これらの画像は存在していなかったようでした。


# Solution


存在しない画像を指しているものにたいして、同名の画像に向けたシンボリックリンクを作成します。
これによって画像が存在するようになるので、画像のリンク切れが改善します。
実際に`bundle exec jekyll serve -I --future`でサーバーを立ち上げて、各画像が表示されることを確認済みです。




github pages でsymlink がうまく動くのか不安でしたが、ググって出てきたテストリポジトリを見る限りうまく動きそうに見えるので、大丈夫かなと思っています。
https://github.com/s4y/gh-pages-symlink-test 