### PR TITLE
Removed unicorn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ gem 'nokogiri'
 gem 'rouge'
 gem 'html-proofer'
 gem 'rack-jekyll'
-gem 'unicorn'
 gem 'rack-rewrite', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,6 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kgio (2.11.4)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -78,7 +77,6 @@ GEM
       rack (~> 1.5)
     rack-rewrite (1.5.1)
     rainbow (3.1.1)
-    raindrops (0.20.0)
     rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -95,9 +93,6 @@ GEM
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     unicode-display_width (2.4.2)
-    unicorn (6.1.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
     webrick (1.8.1)
     yell (2.2.2)
     zeitwerk (2.6.6)
@@ -113,7 +108,6 @@ DEPENDENCIES
   rack-jekyll
   rack-rewrite
   rouge
-  unicorn
 
 BUNDLED WITH
    2.3.26

--- a/_config.yml
+++ b/_config.yml
@@ -16,4 +16,4 @@ kramdown:
   syntax_highlighter: rouge
   autolink: true
 
-exclude: ["vendor", "Gemfile", "Gemfile.lock", "tools", "tmp", "script", "config.ru", "README.md", "unicorn.rb", "hiki_docs"]
+exclude: ["vendor", "Gemfile", "Gemfile.lock", "tools", "tmp", "script", "config.ru", "README.md", "hiki_docs"]

--- a/unicorn.rb
+++ b/unicorn.rb
@@ -1,4 +1,0 @@
-worker_processes 1
-timeout 30
-preload_app true
-


### PR DESCRIPTION
`unicorn` is not necessary now. It's old parts of heroku app.