### PR TITLE
編集コミュニティへの導線の一つとしてフッターを追加

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <div class="container">
     記事へのご意見・ご感想やるびまへのご要望などありましたら、
     <a href="https://github.com/rubima/magazine.rubyist.net/discussions">るびま編集部</a> までお気軽にご連絡ください。
-    編集に参加したいという申し出も歓迎しています。
+    編集に参加したい、記事を寄稿したいという申し出も歓迎しています。
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,5 @@
+<div class="container">
+    記事へのご意見・ご感想やるびまへのご要望などありましたら、
+    <a href="https://github.com/rubima/magazine.rubyist.net/discussions">るびま編集部</a> までお気軽にご連絡ください。
+    編集に参加したいという申し出も歓迎しています。
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,10 @@
                 </div>
             </div>
         </div>
+        <hr>
+        <footer>
+            {% include footer.html %}
+        </footer>
     </div>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -24,6 +24,10 @@
                 </div>
             </div>
         </div>
+        <hr>
+        <footer>
+            {% include footer.html %}
+        </footer>
     </div>
   </body>
 </html>


### PR DESCRIPTION
https://github.com/rubima/magazine.rubyist.net/issues/396#issuecomment-1513932558

> 例えば、「編集部に加わりたい」まで行かなくても、記事を読んでいて「typoを見つけたのでPRを出したい」等のライトな動機を持った場合に、今だと「まずどうすればいいかどこに書いてあるか探す（その結果各号の表紙やFAQにたどり着く...）」という行為が発生しそう。その手間を省いて、このリポジトリに（今よりもうちょっとだけ）辿りつきやすくなっているのも、動線整理の一環に良さそうに思いました！
アイディアとしては、サイドバーの下部にリンクを置く、とか💭

これ、おっしゃる通りだなあと感じたので、編集コミュニティへの導線をフッターに置いてみました。

<img width="1198" alt="スクリーンショット 2023-04-22 7 37 58" src="https://user-images.githubusercontent.com/3954/233744738-a096ba55-0c4b-476c-9b00-b90d14c35fdd.png">

### るびま編集部のリンクについて

現状各号の扉にあるるびま編集部のリンクはメールになっているのですが、Discussionsへのリンクとしておいた方が連絡してもらいやすいかなと思い、このリポジトリのDiscussionsへのリンクにしています。

どうでしょうねえ。