### PR TITLE
editing_tools 配下をビルド対象外に

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,4 +16,4 @@ kramdown:
   syntax_highlighter: rouge
   autolink: true
 
-exclude: ["Gemfile", "Gemfile.lock", "tools", "tmp", "script", "README.md", "hiki_docs", "vendor"]
+exclude: ["Gemfile", "Gemfile.lock", "tools", "tmp", "script", "README.md", "hiki_docs", "vendor", "editing_tools"]


### PR DESCRIPTION
editing_tools 配下の erb ファイルをビルドしようとしてエラーになるので、対象外にした。