### PR TITLE
0062の表紙で間違っていた箇所の修正

### DIFF
--- a/articles/0062/_posts/2023-04-30-0062-index.md
+++ b/articles/0062/_posts/2023-04-30-0062-index.md
@@ -52,9 +52,9 @@ Ruby をはじめるにあたって必要な情報をご紹介します。本稿
 2023 年 4 月 14 日に出版された「研鑽 Ruby プログラミング」の訳者による紹介と書籍プレゼントの案内です。 (難易度：磨)
 
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://scrapbox.io/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://scrapbox.io/ruby-no-kai/RubyEventCheck) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://scrapbox.io/ruby-no-kai) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0062 号 編集後記]({{base}}{% post_url articles/0062/2023-04-30-0062-EditorsNote %})
 

--- a/articles/0062/_posts/2023-04-30-0062-index.md
+++ b/articles/0062/_posts/2023-04-30-0062-index.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Rubyist Magazine 0062 号
-short_title: 0062(2023-04)
+short_title: 0062号(2023-04)
 tags: 0062 index
 ---
 {% include base.html %}


### PR DESCRIPTION
#416 のマージ後に気になったポイントの修正

* 表紙のショートネームがコンベンションとちがっていた
* 日本 Ruby の会の Wiki へのリンクが古いものになっていた