### PR TITLE
Fix typo in 2023-05-22-0063-KeebKaigi2023Report.md

### DIFF
--- a/articles/0063/_posts/2023-05-22-0063-KeebKaigi2023Report.md
+++ b/articles/0063/_posts/2023-05-22-0063-KeebKaigi2023Report.md
@@ -224,4 +224,4 @@ GitHub：[k16shikano](https://github.com/k16shikano)
 ### 脚注
 [^1]: 編集部注: 記事中の撮影クレジットなしの写真は鹿野さん撮影によるもの。
 [^2]: 編集部注: 1 人ずつの抽選を行う際には["`deck.shuffle!.pop` のように `Array#shuffle!` して `Array#pop` すると、重複が起きず読み札がなくなったら終了"](https://blog.agile.esm.co.jp/entry/ruby-method-karuta-retrospective) というコードが良さそうです。
-[^3]: 編集部注: 第 2 回の KeebKaigi の構想は KeebKaigi 2023 Team 内では薄ぼんやりと存在はするのですが、その開催地は 2023 年 5 月の那覇 ( RubyKaigi 2024 合わせ ) ではなさそう、ということだけはほぼ決まっています。待て続報…… [https://keebkaigi.org/](https://keebkaigi.org/)
+[^3]: 編集部注: 第 2 回の KeebKaigi の構想は KeebKaigi 2023 Team 内では薄ぼんやりと存在はするのですが、その開催地は 2024 年 5 月の那覇 ( RubyKaigi 2024 合わせ ) ではなさそう、ということだけはほぼ決まっています。待て続報…… [https://keebkaigi.org/](https://keebkaigi.org/)


### PR DESCRIPTION
RubyKaigi 2024 should be held May 2024, not 2023.