### PR TITLE
0063: RailsGirlsReport を分野別目次に載るように分類する

### DIFF
--- a/articles/0054/_posts/2016-08-21-0054-RailsGirlsTokyo6thReport.md
+++ b/articles/0054/_posts/2016-08-21-0054-RailsGirlsTokyo6thReport.md
@@ -3,7 +3,7 @@ layout: post
 title: Rails Girls Tokyo 6th 開催レポート
 short_title: Rails Girls Tokyo 6th 開催レポート
 created_on: 2016-08-21
-tags: 0054 RailsGirlsTokyo6thReport
+tags: 0054 RailsGirlsTokyo6thReport RailsGirlsReport
 ---
 {% include base.html %}
 

--- a/articles/0054/_posts/2016-08-21-0054-RailsGirlsTokyo6thReport.md
+++ b/articles/0054/_posts/2016-08-21-0054-RailsGirlsTokyo6thReport.md
@@ -3,7 +3,7 @@ layout: post
 title: Rails Girls Tokyo 6th 開催レポート
 short_title: Rails Girls Tokyo 6th 開催レポート
 created_on: 2016-08-21
-tags: 0054 RailsGirlsTokyo6thReport RailsGirlsReport
+tags: 0054 RailsGirlsReport
 ---
 {% include base.html %}
 

--- a/articles/0059/_posts/2019-01-27-0059-RailsGirlsSendai1stReport.md
+++ b/articles/0059/_posts/2019-01-27-0059-RailsGirlsSendai1stReport.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Sendai 1st 開催レポート
 short_title: Rails Girls Sendai 1st 開催レポート
-tags: 0058 RailsGirlsSendai1stReport RailsGirlsReport
+tags: 0058 RailsGirlsReport
 post_author: 大倉雅史（@okuramasafumi）
 created_on: 2019-01-27
 ---

--- a/articles/0059/_posts/2019-01-27-0059-RailsGirlsSendai1stReport.md
+++ b/articles/0059/_posts/2019-01-27-0059-RailsGirlsSendai1stReport.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Sendai 1st 開催レポート
 short_title: Rails Girls Sendai 1st 開催レポート
-tags: 0058 RailsGirlsSendai1stReport
+tags: 0058 RailsGirlsSendai1stReport RailsGirlsReport
 post_author: 大倉雅史（@okuramasafumi）
 created_on: 2019-01-27
 ---

--- a/articles/0059/_posts/2019-01-27-0059-RailsGirlsTokyo10th.md
+++ b/articles/0059/_posts/2019-01-27-0059-RailsGirlsTokyo10th.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Tokyo 10th レポート
 short_title: Rails Girls Tokyo 10th レポート
-tags: 0059 RailsGirlsTokyo RailsGirlsReport
+tags: 0059 RailsGirlsReport
 post_author: katorie
 created_on: 2019-01-27
 ---

--- a/articles/0059/_posts/2019-01-27-0059-RailsGirlsTokyo10th.md
+++ b/articles/0059/_posts/2019-01-27-0059-RailsGirlsTokyo10th.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Tokyo 10th レポート
 short_title: Rails Girls Tokyo 10th レポート
-tags: 0059 RailsGirlsTokyo
+tags: 0059 RailsGirlsTokyo RailsGirlsReport
 post_author: katorie
 created_on: 2019-01-27
 ---

--- a/articles/0060/_posts/2019-08-18-0060-RailsGirlsNagano1stReport.md
+++ b/articles/0060/_posts/2019-08-18-0060-RailsGirlsNagano1stReport.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Nagano 1st 開催レポート
 short_title: Rails Girls Nagano 1st 開催レポート
-tags: 0059 RailsGirlsNagano1stReport
+tags: 0059 RailsGirlsNagano1stReport RailsGirlsReport
 post_author: cobachie
 created_on: 2019-08-10
 ---

--- a/articles/0060/_posts/2019-08-18-0060-RailsGirlsNagano1stReport.md
+++ b/articles/0060/_posts/2019-08-18-0060-RailsGirlsNagano1stReport.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Nagano 1st 開催レポート
 short_title: Rails Girls Nagano 1st 開催レポート
-tags: 0059 RailsGirlsNagano1stReport RailsGirlsReport
+tags: 0059 RailsGirlsReport
 post_author: cobachie
 created_on: 2019-08-10
 ---

--- a/articles/0060/_posts/2019-08-18-0060-RailsGirlsSendai2ndReport.md
+++ b/articles/0060/_posts/2019-08-18-0060-RailsGirlsSendai2ndReport.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Sendai 2nd 開催レポート
 short_title: Rails Girls Sendai 2nd 開催レポート
-tags: 0060 RailsGirlsSendai2ndReport
+tags: 0060 RailsGirlsSendai2ndReport RailsGirlsReport
 post_author: halucaaya
 created_on: 2019-08-18
 ---

--- a/articles/0060/_posts/2019-08-18-0060-RailsGirlsSendai2ndReport.md
+++ b/articles/0060/_posts/2019-08-18-0060-RailsGirlsSendai2ndReport.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Sendai 2nd 開催レポート
 short_title: Rails Girls Sendai 2nd 開催レポート
-tags: 0060 RailsGirlsSendai2ndReport RailsGirlsReport
+tags: 0060 RailsGirlsReport
 post_author: halucaaya
 created_on: 2019-08-18
 ---

--- a/articles/0060/_posts/2019-08-18-0060-RailsGirlsTokyo12th.md
+++ b/articles/0060/_posts/2019-08-18-0060-RailsGirlsTokyo12th.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Tokyo 12th レポート
 short_title: Rails Girls Tokyo 12th レポート
-tags: 0060 RailsGirlsTokyo12thReport
+tags: 0060 RailsGirlsTokyo12thReport RailsGirlsReport
 post_author: chinatz_
 created_on: 2019-08-10
 ---

--- a/articles/0060/_posts/2019-08-18-0060-RailsGirlsTokyo12th.md
+++ b/articles/0060/_posts/2019-08-18-0060-RailsGirlsTokyo12th.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Tokyo 12th レポート
 short_title: Rails Girls Tokyo 12th レポート
-tags: 0060 RailsGirlsTokyo12thReport RailsGirlsReport
+tags: 0060 RailsGirlsReport
 post_author: chinatz_
 created_on: 2019-08-10
 ---

--- a/articles/0062/_posts/2023-04-30-0062-RailsGirlsTokyo14thReport.md
+++ b/articles/0062/_posts/2023-04-30-0062-RailsGirlsTokyo14thReport.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Tokyo 14th 開催レポート
 short_title: Rails Girls Tokyo 14th 開催レポート
-tags: 0062 RailsGirlsTokyo14thReport
+tags: 0062 RailsGirlsTokyo14thReport RailsGirlsReport
 post_author: emorima
 created_on: 2023-04-30
 ---

--- a/articles/0062/_posts/2023-04-30-0062-RailsGirlsTokyo14thReport.md
+++ b/articles/0062/_posts/2023-04-30-0062-RailsGirlsTokyo14thReport.md
@@ -2,7 +2,7 @@
 layout: post
 title: Rails Girls Tokyo 14th 開催レポート
 short_title: Rails Girls Tokyo 14th 開催レポート
-tags: 0062 RailsGirlsTokyo14thReport RailsGirlsReport
+tags: 0062 RailsGirlsReport
 post_author: emorima
 created_on: 2023-04-30
 ---

--- a/articles/backnumber/_posts/2000-01-01-backnumber.md
+++ b/articles/backnumber/_posts/2000-01-01-backnumber.md
@@ -128,7 +128,7 @@ short_title: バックナンバー
 - [{{ post.title }}]({{base}}{{ post.url }})
 {% endfor %}
 
-### RailsGirlsReport
+### Rails Girls レポート
 
 {% for post in site.tags.RailsGirlsReport %}
 - [{{ post.title }}]({{base}}{{ post.url }})

--- a/articles/backnumber/_posts/2000-01-01-backnumber.md
+++ b/articles/backnumber/_posts/2000-01-01-backnumber.md
@@ -128,6 +128,12 @@ short_title: バックナンバー
 - [{{ post.title }}]({{base}}{{ post.url }})
 {% endfor %}
 
+### RailsGirlsReport
+
+{% for post in site.tags.RailsGirlsReport %}
+- [{{ post.title }}]({{base}}{{ post.url }})
+{% endfor %}
+
 ## 各号表紙
 
 {% for post in site.tags.index %}


### PR DESCRIPTION
#445 
- これまでの記事に共通の `RailsGirlsReport` というタグを追加
- 分野別目次ページに RailsGirlsReport が載るように追加

- スクリーンショット
<img width="1637" alt="image" src="https://github.com/rubima/magazine.rubyist.net/assets/40660382/ec87cc4b-77e3-4db5-955d-c745e57cb12a">
