### PR TITLE
Remove replacing index.html to '' from canonical link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,7 +23,7 @@
   <link href="{{base}}{{ site.baseurl }}/css/sharebutton.css" rel="stylesheet" type="text/css">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="canonical" href="{{ page.url  | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
   <link rel="shortcut icon" href="{{base}}{{ site.baseurl }}/images/favicon.ico">
 </head>


### PR DESCRIPTION
Fix #43 
各号の表紙に生成される canonical link に設定されている URL から `index.html` が削除するようになっていたので、削除しないようにしています。

>   <link rel="canonical" href="https://magazine.rubyist.net/articles/0063/0063-">

削除している意図がないか軽く調べたのですが、見つからなかったので、このような修正にしています。