### PR TITLE
cairo記事の修正

### DIFF
--- a/articles/0019/_posts/2007-05-18-0019-cairo.md
+++ b/articles/0019/_posts/2007-05-18-0019-cairo.md
@@ -135,15 +135,13 @@ PNG や GIF などで使用している、各画素に色を割り当てて画�
 
 Ruby で書くとこうです。
 
-{% highlight text %}
-{% raw %}
+```ruby
  def draw_line(start_x, start_y, end_x, end_y)
    move_to(start_x, start_y)
    line_to(end_x, end_y)
    stroke
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 ![context-draw-line.png]({{base}}{{site.baseurl}}/images/0019-cairo/context-draw-line.png)
 
@@ -166,13 +164,11 @@ API がなく、単に線を描くだけなのに 3 つの操作が必要にな�
 縮小したりできます。例えば、点(20, 40)から点(20, 80)までの線
 を描くには以下のようになります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  move_to(20, 40)
  line_to(20, 80)
  stroke
-{% endraw %}
-{% endhighlight %}
+```
 
 
 これを、全体的に右に 40 分ずらして、点(60, 40)から点(60, 80)ま
@@ -181,26 +177,22 @@ API がなく、単に線を描くだけなのに 3 つの操作が必要にな�
 
 変換行列を使わず、単純にやる場合はこうなるでしょう。
 
-{% highlight text %}
-{% raw %}
+```ruby
  move_to(60, 40)
  line_to(60, 80)
  stroke
-{% endraw %}
-{% endhighlight %}
+```
 
 
 変換行列を使えばこうなります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  translate(40, 0)
 
  move_to(20, 40)
  line_to(20, 80)
  stroke
-{% endraw %}
-{% endhighlight %}
+```
 
 
 translate で x 座標だけを右に 40 分ずらしています[^3]。注目してほしいのは
@@ -212,8 +204,7 @@ move_to と line_to の引数が変わっていないところです。
 処理の部分を描くことができます。scale は拡大／縮小率を
 設定します。
 
-{% highlight text %}
-{% raw %}
+```ruby
  # width/height は実際の描画領域の幅／高さ
  scale(width / 100.0, height / 100.0)
 
@@ -221,8 +212,7 @@ move_to と line_to の引数が変わっていないところです。
  move_to(0, 0)
  line_to(100, 100)
  stroke
-{% endraw %}
-{% endhighlight %}
+```
 
 
 この機能はサイズの違う結果を複数生成したい場合に便利です。サ
@@ -333,26 +323,22 @@ Ruby で cairo を使うには rcairo を使います。rcairo は Ruby と cair
 おいた状態を復元する restore という API があります。これら
 は以下のようにペアで使います。
 
-{% highlight text %}
-{% raw %}
+```ruby
  save
  ...
  restore
-{% endraw %}
-{% endhighlight %}
+```
 
 
 save だけを呼んで restore を呼ぶことを忘れないため
 にブロックを使うこともできます。これはちょうど open のブ
 ロックの使いかたと同じです。
 
-{% highlight text %}
-{% raw %}
+```ruby
  save do
    ...
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 
 ### 流れ
@@ -391,8 +377,7 @@ Cairo::Surface のサブクラスになっています。このようにたく�
 
 スクリプト: [hinomaru.rb]({{base}}{{site.baseurl}}/images/0019-cairo/hinomaru.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'cairo'
 
  format = Cairo::FORMAT_ARGB32
@@ -414,8 +399,7 @@ Cairo::Surface のサブクラスになっています。このようにたく�
  context.fill
 
  surface.write_to_png("hinomaru.png")
-{% endraw %}
-{% endhighlight %}
+```
 
 
 以下の通り、順に説明します。
@@ -451,31 +435,25 @@ Cairo::FORMAT_ARGB32 を指定すればよいでしょう。
 幅 300、高さ 200 の画像を作成したい場合は、以下のように
 Cairo::ImageSurface を作ることになります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  surface = Cairo::ImageSurface.new(Cairo::FORMAT_ARGB32, 300, 200)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 実は、1.4.0 以降の rcairo では Cairo::FORMAT_ARGB32 を省略して以下
 のように書くこともできます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  surface = Cairo::ImageSurface.new(300, 200)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 さらに、現在はまだリリースされていない 1.6.0 以降 では Cairo::FORMAT_
 を省略して以下のように書くこともできます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  surface = Cairo::ImageSurface.new(:argb32, 300, 200)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 他にも PNG 画像を読み込んで Cairo::ImageSurface を作る方法や、生
@@ -490,11 +468,9 @@ Cairo::ImageSurface を作ることになります。
 コンテキストの作り方は簡単です。操作対象のサーフェスを渡すだ
 けです。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context = Cairo::Context.new(surface)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 サーフェスへの操作はこのコンテキストを経由して行います。下準
@@ -514,8 +490,7 @@ Cairo::ImageSurface を作ることになります。
 色は RGB 形式で set_source_rgb を使って設定します。RGB は 0.0-1.0
 までの間で指定します。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.set_source_rgb(1, 0, 0) # 赤
  context.set_source_rgb(0, 1, 0) # 青
  context.set_source_rgb(0, 0, 1) # 緑
@@ -523,8 +498,7 @@ Cairo::ImageSurface を作ることになります。
  context.set_source_rgb(1, 1, 1) # 白
  context.set_source_rgb(1, 1, 0) # 黄
  context.set_source_rgb(0.9, 0.9, 0.9) # 薄いグレー
-{% endraw %}
-{% endhighlight %}
+```
 
 
 色だけではなく、アルファ値やグラデーションも設定できます。
@@ -533,45 +507,37 @@ Cairo::ImageSurface を作ることになります。
 1.6.0 でかなり改善されます。まず、以下のように約 250 種類の有名
 な色があらかじめ利用できます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  Cairo::Color::RED
  Cairo::Color::WHITE
  Cairo::Color::ROSE
  ...
-{% endraw %}
-{% endhighlight %}
+```
 
 
 これらはコンテキストの色指定として利用できます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.set_source_color(Cairo::Color::GREEN)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 また、文字列を色に変換することもできます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  Cairo::Color.parse("red")  # => Cairo::Color::RED
  Cairo::Color.parse("#f00") # => Cairo::Color::RED
  Cairo::Color.parse("#ff000033") # Cairo::Color::RED で
                                  # アルファ値が 0.2
                                  #  (51/255, "33".hex == 51)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 実は、コンテキストの色指定に上述の文字列指定も可能になります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.set_source_color("red") # == context.set_source_rgb(1, 0, 0)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 他にも RGB だけではなく CMYK、HSV がサポートされます。もちろん、
@@ -590,21 +556,17 @@ rcairo では角が丸まった四角形のパスを作る rounded_rectangle を
 日の丸の例では、まず、背景を真っ白に塗りつぶすために画像全体
 と同じ大きさの四角形のパスを作っています。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.rectangle(0, 0, width, height)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 その後の赤い丸を描く処理では arc を使って丸いパスを作っていま
 す。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.arc(width / 2, height / 2, radius, 0, 2 * Math::PI)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 arc には円の中心となる点を指定します。赤い丸を画像の中央に描
@@ -630,40 +592,32 @@ arc には中央の点だけではなく、半径と円をどの角度からど�
 日の丸の赤い丸はどこも欠けていないので、一周分 (0 から 2 *
 Math::PI) の円を描いています。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.arc(..., 0, 2 * Math::PI)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 8 等分されたうち 1 切れ食べられたホールケーキを描くときは以下の
 ようになります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.arc(..., 0, (2 * Math::PI) * (7.0 / 8.0))
-{% endraw %}
-{% endhighlight %}
+```
 
 
 実は、今回の日の丸のようにどこも欠けていない円を描くために
 circle を使えます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.circle(width / 2, height / 2, radius)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 これは以下のように書くことと同じです。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.arc(width / 2, height / 2, radius, 0, 2 * Math::PI)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 この完全な円を描くための便利なメソッド circle は cairo の API には
@@ -688,8 +642,7 @@ fill も stroke もパスを描くとパスを消してしまいます。通常�
 
 この場合は fill_preserve と stroke_preserve を使います。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.set_source_rgb(1, 0, 0)
  context.rectangle(50, 50, 100, 100)
 
@@ -699,45 +652,38 @@ fill も stroke もパスを描くとパスを消してしまいます。通常�
  # 黒く縁どり
  context.set_source_rgb(0, 0, 0)
  context.stroke
-{% endraw %}
-{% endhighlight %}
+```
 
 
 より Ruby っぽく書けるように fill や stroke はブロックをとれます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.set_source_rgb(1, 0, 0)
  context.rectangle(50, 50, 100, 100)
  context.fill
-{% endraw %}
-{% endhighlight %}
+```
 
 
 この例は以下のようにも書けます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.fill do
    context.set_source_rgb(1, 0, 0)
    context.rectangle(50, 50, 100, 100)
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 
 この書き方の利点は break を使って途中で処理をやめることができ
 たり、fill の対象が明示的になるということです。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.fill do
    context.set_source_rgb(1, 0, 0)
    break if error_occurs
    context.rectangle(50, 50, 100, 100)
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 
 基本的な描画方法は以上の通りです。この他にもたくさん便利な操
@@ -761,35 +707,29 @@ Cairo::ImageSurface では write_to_png を使って PNG 形式で描画内容
 を出力します。例では以下のようにサーフェス作成時に持っておい
 たサーフェスに対して write_to_png を呼び出していました。
 
-{% highlight text %}
-{% raw %}
+```ruby
  surface.write_to_png("hinomaru.png")
-{% endraw %}
-{% endhighlight %}
+```
 
 
 サーフェスはコンテキストから取り出すことができるので以下のよ
 うに書くこともできます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.target.write_to_png("hinomaru.png")
-{% endraw %}
-{% endhighlight %}
+```
 
 
 Cairo::ImageSurface 以外のサーフェスでは finish を呼ぶことで出力
 をするものが多いです。例えば、PDF を生成するサーフェスなどがそ
 うです。[^10]
 
-{% highlight text %}
-{% raw %}
+```ruby
  surface = Cairo::PDFSurface.new(...)
  context = Cairo::Context.new(surface)
  ...
  context.target.finish
-{% endraw %}
-{% endhighlight %}
+```
 
 
 ### 基本の流れのまとめ
@@ -837,8 +777,7 @@ Ruby/RSVG は Ruby-GNOME2 プロジェクトに含まれています。
 
 スクリプト: [svg2png.rb]({{base}}{{site.baseurl}}/images/0019-cairo/svg2png.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  #!/usr/bin/env ruby
 
  require "rsvg2"
@@ -865,8 +804,7 @@ Ruby/RSVG は Ruby-GNOME2 プロジェクトに含まれています。
  context.render_rsvg_handle(handle)
 
  surface.write_to_png(input.sub(/\.[^.]+$/i, '.png'))
-{% endraw %}
-{% endhighlight %}
+```
 
 
 使い方はこうなります。
@@ -892,11 +830,9 @@ Ruby/RSVG は Ruby-GNOME2 プロジェクトに含まれています。
 
 Ruby/RSVG を使うには以下のように rsvg2 を require します。
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'rsvg2'
-{% endraw %}
-{% endhighlight %}
+```
 
 
 もし、システムに rcairo がインストールされていれば自動で rcairo
@@ -912,11 +848,9 @@ librsvg では SVG を操作するためにハンドルというオブジェク�
 今回はファイルから SVG 画像を読み込み、RSVG::Handle オブジェク
 トを作ります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  handle = RSVG::Handle.new_from_file(input)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 これだけで SVG 画像を描画する準備が整います。あとは出力用のサー
@@ -934,35 +868,29 @@ Cairo::ImageSurface を使います。Cairo::ImageSurface を作るには
 dimensions メソッドは幅や高さなどを RSVG::DimensionData オブジェ
 クトとして返します。
 
-{% highlight text %}
-{% raw %}
+```ruby
  dim = handle.dimensions
  width = dim.width * ratio
  height = dim.height * ratio
-{% endraw %}
-{% endhighlight %}
+```
 
 
 今回は幅と高さだけが必要なので、以下のように to_a で配列化し、
 幅と高さだけを取り出すという方法もあります
 [^11]。
 
-{% highlight text %}
-{% raw %}
+```ruby
  width, height, = handle.dimensions.to_a
  width *= ratio
  height *= ratio
-{% endraw %}
-{% endhighlight %}
+```
 
 
 幅と高さがわかったのでサーフェスを作ります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  surface = Cairo::ImageSurface.new(Cairo::FORMAT_ARGB32, width, height)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 #### SVG の描画
@@ -970,31 +898,25 @@ dimensions メソッドは幅や高さなどを RSVG::DimensionData オブジェ
 ハンドルが持っている SVG 画像をサーフェスに描画するためにコン
 テキストを作ります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context = Cairo::Context.new(surface)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 render_rsvg_handle でコンテキストにハンドルを描画します
 [^12]。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.render_rsvg_handle(handle)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 しかし、このままだと拡大率が反映されず、元の SVG 画像と同じ大き
 さで描画されてしまいます。拡大率を変更するには scale を使います。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.scale(ratio, ratio)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 今回は縦も横も同じ拡大率を使うため、ratio が 2 つ並んでいます。
@@ -1003,22 +925,18 @@ scale で拡大率を設定すると、それ以降は設定した拡大率で�
 ます。今回は拡大率に合わせて SVG 画像を描画したいので
 render_rsvg_handle の前に scale を呼ぶ必要があります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.scale(ratio, ratio)
  context.render_rsvg_handle(handle)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 これでサーフェスに SVG 画像と同じ内容が設定した拡大率で描画さ
 れます。あとは PNG 画像を出力するだけです。
 
-{% highlight text %}
-{% raw %}
+```ruby
  surface.write_to_png(input.sub(/\.[^.]+$/i, '.png'))
-{% endraw %}
-{% endhighlight %}
+```
 
 
 以上で SVG 画像を PNG 画像に変換できます。
@@ -1049,8 +967,7 @@ GdkPixbuf は以下の 3 つの機能を提供します。
 
 スクリプト: [png-to-inverted-jpeg.rb]({{base}}{{site.baseurl}}/images/0019-cairo/png-to-inverted-jpeg.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'gdk_pixbuf2'
 
  input = ARGV.shift
@@ -1058,8 +975,7 @@ GdkPixbuf は以下の 3 つの機能を提供します。
  pixbuf = Gdk::Pixbuf.new(input)
  inverted_pixbuf = pixbuf.flip(false)
  inverted_pixbuf.save(output, "jpeg")
-{% endraw %}
-{% endhighlight %}
+```
 
 
 GdkPixbuf は画像形式を自動認識できます。そのため、任意の形式
@@ -1067,15 +983,13 @@ GdkPixbuf は画像形式を自動認識できます。そのため、任意の�
 
 スクリプト: [image2png.rb]({{base}}{{site.baseurl}}/images/0019-cairo/image2png.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'gdk_pixbuf2'
 
  input = ARGV.shift
  output = input.sub(/\.[^.]+$/i, ".png")
  Gdk::Pixbuf.new(input).save(output, "png")
-{% endraw %}
-{% endhighlight %}
+```
 
 
 GdkPixbuf がサポートしている画像形式は PNG や JPEG、GIF など 10 数種
@@ -1108,8 +1022,7 @@ Cairo::PSSurface と SVG を出力する Cairo::SVGSurface が show_page
 
 スクリプト: [image2pdf.rb]({{base}}{{site.baseurl}}/images/0019-cairo/image2pdf.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'gdk_pixbuf2'
  require 'cairo'
 
@@ -1129,8 +1042,7 @@ Cairo::PSSurface と SVG を出力する Cairo::SVGSurface が show_page
  context.show_page
 
  surface.finish
-{% endraw %}
-{% endhighlight %}
+```
 
 
 このスクリプトでるびまのロゴを変換すると以下のようになります。
@@ -1148,14 +1060,12 @@ Cairo::PSSurface と SVG を出力する Cairo::SVGSurface が show_page
 せん。これより前のバージョンでも動くようにするには以下のよう
 にします。
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'gtk2' # 追加
 
  context.set_source_pixbuf(pixbuf)       # 変更前
  context.set_source_pixbuf(pixbuf, 0, 0) # 変更後
-{% endraw %}
-{% endhighlight %}
+```
 
 
 ただし、このスクリプトは X Window System など GUI 環境がないと動
@@ -1163,11 +1073,9 @@ Cairo::PSSurface と SVG を出力する Cairo::SVGSurface が show_page
 て、ちょっとした小細工をすると動作します。問題は以下の部分で
 す。
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'gtk2'
-{% endraw %}
-{% endhighlight %}
+```
 
 
 0.16.0 より前のバージョンでは rcairo と Ruby/GdkPixbuf2 を連携させ
@@ -1179,14 +1087,12 @@ rcairo と Ruby/GdkPixbuf2 の連携部分は GUI 環境がなくても動作し
 す。つまり、GUI 環境の初期化が失敗したという例外は無視してもよ
 いのです。そこで、以下のようにします。
 
-{% highlight text %}
-{% raw %}
+```ruby
  begin
    require 'gtk2'
  rescue RuntimeError
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 
 これで GUI 環境がなくても動作します。
@@ -1207,15 +1113,13 @@ PDF 形式用のサーフェスは Cairo::PDFSurface です。今回はこのサ
 幅と高さはポイントで指定します。今回は画像と同じ大きさのペー
 ジを作成するので以下のようになります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  output = input.sub(/\.[^.]+$/i, ".pdf")
  width = pixbuf.width
  height = pixbuf.height
 
  surface = Cairo::PDFSurface.new(output, width, height)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 実は、ファイルではなく、ネットワーク上やメモリ上に出力するこ
@@ -1223,15 +1127,13 @@ PDF 形式用のサーフェスは Cairo::PDFSurface です。今回はこのサ
 を持ったオブジェクトを指定します。以下はメモリ上に PDF を出力
 する例です。
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'stringio'
  output = StringIO.new("")
  surface = Cairo::PDFSurface.new(output, width, height)
  ...
  pdf = output.string
-{% endraw %}
-{% endhighlight %}
+```
 
 
 StringIO オブジェクトの代わりに Socket オブジェクトを指定すれば、
@@ -1266,27 +1168,23 @@ set_source_rgb で色を指定し、ソースを設定していました。こ�
 
 コードにするとこうなります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  width = pixbuf.width
  height = pixbuf.height
 
  context.set_source_pixbuf(pixbuf)
  context.rectangle(0, 0, width, height)
  context.fill
-{% endraw %}
-{% endhighlight %}
+```
 
 
 実は、画像の描画には rectangle と fill の組合せよりも paint の方が
 便利です。paint を使うとこうなります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.set_source_pixbuf(pixbuf)
  context.paint
-{% endraw %}
-{% endhighlight %}
+```
 
 
 paint は現在設定されているソースでサーフェス全体を塗りつぶす
@@ -1297,12 +1195,10 @@ paint の利点はパスを作らなくてもよいというだけではあり�
 アルファ値を設定することもできます。例えば、以下のようにする
 と画像全体が半透明になって描画されます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.set_source_pixbuf(pixbuf)
  context.paint(0.5)
-{% endraw %}
-{% endhighlight %}
+```
 
 ![paint-without-alpha-and-paint-with-alpha.png]({{base}}{{site.baseurl}}/images/0019-cairo/paint-without-alpha-and-paint-with-alpha.png)
 
@@ -1332,14 +1228,12 @@ close されるという関係と似ています。
 次の rcairo のリリース (おそらく 1.6.0) では File.open の
 ように以下のように書けるようになります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  Cairo::ImageSurface.new(300, 300) do |surface|
    context = Cairo::Context.new(surface)
    ...
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 
 この書き方では File.open と同じように、ブロックを抜けるときに
@@ -1357,8 +1251,7 @@ close されるという関係と似ています。
 
 スクリプト: [image2pdf-with-margin.rb]({{base}}{{site.baseurl}}/images/0019-cairo/image2pdf-with-margin.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'gdk_pixbuf2'
  require 'cairo'
 
@@ -1382,8 +1275,7 @@ close されるという関係と似ています。
  context.show_page
 
  surface.finish
-{% endraw %}
-{% endhighlight %}
+```
 
 
 #### translate
@@ -1393,13 +1285,11 @@ close されるという関係と似ています。
 ると思いますが、translate はパスを平行移動させるときに
 も使っていました。
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.translate(margin, margin)
  context.set_source_pixbuf(pixbuf)
  context.paint
-{% endraw %}
-{% endhighlight %}
+```
 
 
 大事なことは set_source_pixbuf を呼ぶ前に translate
@@ -1441,8 +1331,7 @@ Ruby/Poppler は Ruby-GNOME2 プロジェクトに含まれています。
 
 スクリプト: [pdf-thumbnail.rb]({{base}}{{site.baseurl}}/images/0019-cairo/pdf-thumbnail.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  #!/usr/bin/env ruby
 
  require "poppler"
@@ -1495,8 +1384,7 @@ Ruby/Poppler は Ruby-GNOME2 プロジェクトに含まれています。
  context.show_page unless need_show_page
 
  surface.finish
-{% endraw %}
-{% endhighlight %}
+```
 
 
 スクリプトが長くなって非常に心苦しいです。
@@ -1525,11 +1413,9 @@ Ruby/Poppler は Ruby-GNOME2 プロジェクトに含まれています。
 
 Ruby/Poppler を使うには以下のように poppler を require します。
 
-{% highlight text %}
-{% raw %}
+```ruby
  require "poppler"
-{% endraw %}
-{% endhighlight %}
+```
 
 
 もし、システムに rcairo がインストールされていれば自動で rcairo
@@ -1544,22 +1430,18 @@ poppler では PDF 文書がドキュメントオブジェクトに対応しま�
 
 これを行うための慣用句が以下になります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  input_uri = GLib.filename_to_uri(File.expand_path(input))
  document = Poppler::Document.new(input_uri)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 しかし、これではさすがに使いづらいので、次のリリースから (お
 そらく Ruby-GNOME2 0.17) は以下のように書けます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  document = Poppler::Document.new(input)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 つまり、URI ではなく直接ファイル名を指定できるようになります。
@@ -1577,12 +1459,10 @@ poppler では PDF 文書がドキュメントオブジェクトに対応しま�
 
 出力ファイル名は入力ファイル名に -thumb を付けることにしました。
 
-{% highlight text %}
-{% raw %}
+```ruby
  input = ARGV.shift
  output = input.sub(/(\.[^.]+)$/, '-thumb\1')
-{% endraw %}
-{% endhighlight %}
+```
 
 
 ページの幅と高さは元の PDF 文書の最初のページの幅と高さと同じに
@@ -1591,54 +1471,44 @@ poppler では PDF 文書がドキュメントオブジェクトに対応しま�
 ドキュメントオブジェクトから各ページへは配列のようにアクセス
 できます。例えば、3 ページには以下のようにアクセスできます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  third_page = document[2]
-{% endraw %}
-{% endhighlight %}
+```
 
 
 各ページを順番にアクセスしたい場合は each が使えます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  document.each do |page|
    ...
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 
 本当に配列としてアクセスしたい場合は pages を使います。
 
-{% highlight text %}
-{% raw %}
+```ruby
  p document.pages # [#<Poppler::Page:...>, ...]
-{% endraw %}
-{% endhighlight %}
+```
 
 
 ページの幅と高さは size で取り出せます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  first_page = document[0]
  width, height = first_page.size
-{% endraw %}
-{% endhighlight %}
+```
 
 
 これで最初のページの幅と高さを取得することが出来るようになり
 ました。以下のように Cairo::PDFSurface を作ることが出来ます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  first_page = document[0]
  width, height = first_page.size
  surface = Cairo::PDFSurface.new(output, width, height)
  context = Cairo::Context.new(surface)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 #### ページの描画
@@ -1659,8 +1529,7 @@ need_show_page は 1 ページに表示する最後の縮小ページを描画�
 ときに真になります。例えば、図だと 1 ページには 6 ページ分の縮小
 ページを描画するので、6 ページ毎に真になります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  need_show_page = true
  document.each_with_index do |page, i|
    ...
@@ -1675,8 +1544,7 @@ need_show_page は 1 ページに表示する最後の縮小ページを描画�
    context.show_page if need_show_page
  end
  context.show_page unless need_show_page
-{% endraw %}
-{% endhighlight %}
+```
 
 
 描画する x/y 座標の変更を translate で行うのは
@@ -1686,8 +1554,7 @@ image2pdf-with-margin.rb の例と同じです。元の描画対象を縮小さ
 上記のコードで省略した以下の部分は縮小したページに枠を描画し
 ています。
 
-{% highlight text %}
-{% raw %}
+```ruby
  document.each_with_index do |page, i|
    ...
    context.save do
@@ -1698,36 +1565,29 @@ image2pdf-with-margin.rb の例と同じです。元の描画対象を縮小さ
    end
    ...
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 
 rectangle が
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.rectangle(x, y, width_per_page, height_per_page)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 ではなく、
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.rectangle(0, 0, width, height)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 となっているのはその前にある
 
-{% highlight text %}
-{% raw %}
+```ruby
  context.translate(x, y)
  context.scale(x_ratio, y_ratio)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 の影響を受けるからです。
@@ -1751,8 +1611,7 @@ GUI 環境なしで動きます。
 
 スクリプト: [text2ps.rb]({{base}}{{site.baseurl}}/images/0019-cairo/text2ps.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  require 'pango'
 
  input = ARGV.shift
@@ -1771,8 +1630,7 @@ GUI 環境なしで動きます。
  context.show_page
 
  surface.finish
-{% endraw %}
-{% endhighlight %}
+```
 
 
 このスクリプトにスクリプト自身を与えると以下のようになります。
@@ -1782,11 +1640,9 @@ GUI 環境なしで動きます。
 
 Ruby/Pango を使うには以下のように pango を require します。
 
-{% highlight text %}
-{% raw %}
+```ruby
  require "pango"
-{% endraw %}
-{% endhighlight %}
+```
 
 
 もし、システムに rcairo がインストールされていれば自動で rcairo
@@ -1806,22 +1662,18 @@ Pango ではレイアウト (Pango::Layout) がテキストの描画のしかた
 Pango を cairo と一緒に使う場合は、コンテキストからレイアウトを
 作ります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  layout = context.create_pango_layout
-{% endraw %}
-{% endhighlight %}
+```
 
 
 単にテキストをデフォルトの設定でそのまま描画するだけなら、こ
 れで十分です。
 
-{% highlight text %}
-{% raw %}
+```ruby
  layout.text = text
  context.show_pango_layout(layout)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 用紙サイズで折り返したいなら幅を指定します。注意しなければい
@@ -1829,11 +1681,9 @@ Pango を cairo と一緒に使う場合は、コンテキストからレイア�
 ピクセルを Pango の世界の単位に変換するには Pango::SCALE
 を掛けます。
 
-{% highlight text %}
-{% raw %}
+```ruby
  layout.width = width * Pango::SCALE
-{% endraw %}
-{% endhighlight %}
+```
 
 
 折り返しの区切りは単語単位か文字単位になります。日本語ではど
@@ -1841,53 +1691,45 @@ Pango を cairo と一緒に使う場合は、コンテキストからレイア�
 
 単語単位:
 
-{% highlight text %}
-{% raw %}
+```ruby
  | layout.width  |
  |<------------->|
  long long long
  long long long
  long
-{% endraw %}
-{% endhighlight %}
+```
 
 
 文字単位:
 
-{% highlight text %}
-{% raw %}
+```ruby
  | layout.width  |
  |<------------->|
  long long long lo
  ng long long long
-{% endraw %}
-{% endhighlight %}
+```
 
 
 Pango での指定のしかたはそれぞれ以下のようになります。
 
-{% highlight text %}
-{% raw %}
+```ruby
  layout.wrap = Pango::WRAP_WORD # 単語単位
  layout.wrap = Pango::WRAP_CHAR # 文字単位
-{% endraw %}
-{% endhighlight %}
+```
 
 
 他にもレイアウトにはたくさんのオプションが設定できます。例え
 ば、以下のように入力テキストにマークアップをして背景色を設定
 できたりします。
 
-{% highlight text %}
-{% raw %}
+```ruby
  markup = "t<span background='green'>ex</span>t"
  attr_list, text = Pango.parse_markup(markup)
  layout = context.create_pango_layout
  layout.text = text
  layout.attributes = attr_list
  context.show_pango_layout(layout)
-{% endraw %}
-{% endhighlight %}
+```
 
 
 実行すると図のように「ex」の部分の背景色だけが緑色になります。  
@@ -1904,20 +1746,17 @@ Ruby/GTK2 に関してはここでは詳しく説明しませんが、GTK+ で�
 るためには以下のようにすればよいということだけわかれば読める
 と思います。
 
-{% highlight text %}
-{% raw %}
+```ruby
  drawing_area.signal_connect("expose-event") do |widget, event|
    context = widget.window.create_cairo_context
    # context を使って描画
  end
-{% endraw %}
-{% endhighlight %}
+```
 
 
 スクリプト: [image-viewer.rb]({{base}}{{site.baseurl}}/images/0019-cairo/image-viewer.rb)
 
-{% highlight text %}
-{% raw %}
+```ruby
  #!/usr/bin/env ruby
 
  require 'gtk2'
@@ -1983,8 +1822,7 @@ Ruby/GTK2 に関してはここでは詳しく説明しませんが、GTK+ で�
  window.show_all
 
  Gtk.main
-{% endraw %}
-{% endhighlight %}
+```
 
 
 ### 他のライブラリとの連携のまとめ

--- a/articles/0019/_posts/2007-05-18-0019-cairo.md
+++ b/articles/0019/_posts/2007-05-18-0019-cairo.md
@@ -278,7 +278,7 @@ Ruby から cairo を使うためには rcairo というライブラリを使う
 本稿では「ぼかし」風画像効果については扱いません。使いかたは
 rcairo のリポジトリにあるサンプルファイルを参考にしてください。
 
-[http://webcvs.cairographics.org/rcairo/samples/blur.rb?revision=HEAD&amp;view=markup](http://webcvs.cairographics.org/rcairo/samples/blur.rb?revision=HEAD&view=markup)
+[https://github.com/rcairo/rcairo/tree/master/samples](https://github.com/rcairo/rcairo/tree/master/samples)
 
 ### rcairo の欠点
 
@@ -2064,12 +2064,12 @@ cairo は Firefox や GTK+ などの有名プロジェクトのバックエン�
 [^1]: UNIX 環境でもっともよく使われている GUI ツールキットの 1 つ
 [^2]: 便利のために上述の draw_line のようなメソッドを作ればよいのかもしれませんが、そのようなメソッドは提供されていません。提供した方がよいでしょうか。
 [^3]: \+ の方向が右で、-の方向が左です。
-[^4]: [Web 2.0 Graphics](http://rmagick.rubyforge.org/web2/web2-3.html)参照
+[^4]: [Web 2.0 Graphics](http://web.archive.org/web/20170315035223/http://rmagick.rubyforge.org/web2/web2-3.html)参照
 [^5]: Ruby-GNOME2 プロジェクトが公開しているバイナリ群に rcairo のバイナリも含まれている。
-[^6]: MacPorts 用の Portfile: http://www.cozmixng.org/repos/dports/trunk/ruby/rb-rcairo/Portfile
+[^6]: MacPorts 用の Portfile: [http://www.cozmixng.org/repos/dports/trunk/ruby/rb-rcairo/Portfile](http://www.cozmixng.org/repos/dports/trunk/ruby/rb-rcairo/Portfile)
 [^7]: PNG 画像を作成するときは 4.を省略できます。GTK+ とともに使う場合は 1.と 4.を省略できます。
 [^8]: キャンバスを載せる台のことをそういうみたいです。
-[^9]: [リファレンスマニュアル](http://cairo.rubyforge.org/doc/ja/)
+[^9]: [リファレンスマニュアル](https://rcairo.github.io/doc/ja/)
 [^10]: cairo 1.4.x からは finish は省略可能になりました。
 [^11]: RSVG::DimensionData#to_ary を定義してもよいかもしれません。よし、定義しよう。した。
 [^12]: Ruby/RSVG が rcairo をサポートしていなければ Cairo::Context#render_rsvg_handle は定義されません。Ruby/RSVG が rcairo をサポートしているかは RSVG.cairo_available?で判断できます。

--- a/articles/0019/_posts/2007-05-18-0019-cairo.md
+++ b/articles/0019/_posts/2007-05-18-0019-cairo.md
@@ -10,6 +10,8 @@ tags: 0019 cairo
 
 書いた人：須藤功平
 
+2024/01/17 更新: 北市真 脚注リンクと画像位置、リンク切れの修正、及びコードブロックのハイライト
+
 ## はじめに
 
 ![objects-without-aa-and-alpha.png]({{base}}{{site.baseurl}}/images/0019-cairo/objects-without-aa-and-alpha.png)

--- a/articles/0019/_posts/2007-05-18-0019-cairo.md
+++ b/articles/0019/_posts/2007-05-18-0019-cairo.md
@@ -2061,33 +2061,17 @@ cairo は Firefox や GTK+ などの有名プロジェクトのバックエン�
 
 ----
 
-[^1]: UNIX 環境でもっともよく使われている GUI
-ツールキットの 1 つ
-[^2]: 便利のために上述の draw_line のよ
-うなメソッドを作ればよいのかもしれませんが、そのようなメソッ
-ドは提供されていません。提供した方がよいでしょうか。
-[^3]: + の方向
-が右で、-の方向が左です。
-[^4]: [Web 2.0 Graphics](http://rmagick.rubyforge.org/web2/web2-3.html)
-参照
-[^5]: Ruby-GNOME2 プロジェクトが公開してい
-るバイナリ群に rcairo のバイナリも含まれている。
-[^6]: MacPorts 用の Portfile:
-http://www.cozmixng.org/repos/dports/trunk/ruby/rb-rcairo/Portfile
-[^7]: PNG
-画像を作成するときは 4.を省略できます。GTK+ とともに使う場合は
-1.と 4.を省略できます。
-[^8]: キャンバスを載せる台のことをそういうみたい
-です。
+[^1]: UNIX 環境でもっともよく使われている GUI ツールキットの 1 つ
+[^2]: 便利のために上述の draw_line のようなメソッドを作ればよいのかもしれませんが、そのようなメソッドは提供されていません。提供した方がよいでしょうか。
+[^3]: \+ の方向が右で、-の方向が左です。
+[^4]: [Web 2.0 Graphics](http://rmagick.rubyforge.org/web2/web2-3.html)参照
+[^5]: Ruby-GNOME2 プロジェクトが公開しているバイナリ群に rcairo のバイナリも含まれている。
+[^6]: MacPorts 用の Portfile: http://www.cozmixng.org/repos/dports/trunk/ruby/rb-rcairo/Portfile
+[^7]: PNG 画像を作成するときは 4.を省略できます。GTK+ とともに使う場合は 1.と 4.を省略できます。
+[^8]: キャンバスを載せる台のことをそういうみたいです。
 [^9]: [リファレンスマニュアル](http://cairo.rubyforge.org/doc/ja/)
 [^10]: cairo 1.4.x からは finish は省略可能になりました。
-[^11]: RSVG::DimensionData#to_ary を定義してもよいかもしれませ
-ん。よし、定義しよう。した。
-[^12]: Ruby/RSVG が rcairo をサポートしていなければ
-Cairo::Context#render_rsvg_handle は定義されません。Ruby/RSVG
-が rcairo をサポートしているかは RSVG.cairo_available?で判断で
-きます。
-[^13]: Ruby/Poppler が rcairo をサポートしているかは
-Poppler.cairo_available? で判断できます。
-[^14]: Ruby/Pango が rcairo をサポートしているかは
-Pango.cairo_available? で判断できます。
+[^11]: RSVG::DimensionData#to_ary を定義してもよいかもしれません。よし、定義しよう。した。
+[^12]: Ruby/RSVG が rcairo をサポートしていなければ Cairo::Context#render_rsvg_handle は定義されません。Ruby/RSVG が rcairo をサポートしているかは RSVG.cairo_available?で判断できます。
+[^13]: Ruby/Poppler が rcairo をサポートしているかは Poppler.cairo_available? で判断できます。
+[^14]: Ruby/Pango が rcairo をサポートしているかは Pango.cairo_available? で判断できます。

--- a/articles/0019/_posts/2007-05-18-0019-cairo.md
+++ b/articles/0019/_posts/2007-05-18-0019-cairo.md
@@ -106,7 +106,7 @@ PNG や GIF などで使用している、各画素に色を割り当てて画�
 にどの色を割り当てるかは実際に描画するときに決定します。例え
 ば、線を引く場合は点 A から点 B まで赤で線を引く、という情報を持っ
 ていて、実際に描画するときに点 A から点 B までの間でどの画素に赤
-を割り当てればよいのかを計算します。
+を割り当てればよいのかを計算します。  
 ![raster-and-vector-draw-line.png]({{base}}{{site.baseurl}}/images/0019-cairo/raster-and-vector-draw-line.png)
 
 このようにすることで画素の色を適当に推測する必要がなくなり、
@@ -176,7 +176,7 @@ API がなく、単に線を描くだけなのに 3 つの操作が必要にな�
 
 
 これを、全体的に右に 40 分ずらして、点(60, 40)から点(60, 80)ま
-での線を描くようにします。
+での線を描くようにします。  
 ![context-move-by-matrix.png]({{base}}{{site.baseurl}}/images/0019-cairo/context-move-by-matrix.png)
 
 変換行列を使わず、単純にやる場合はこうなるでしょう。
@@ -238,7 +238,7 @@ GTK+ や Windows、Mac OS X のウィジェットに描画することもでき�
 translate などといった描画関係の処理を変更する必要はあ
 りません。出力先が画像フォーマットでも、ウィジェットでも同じ
 ものを使用できます。これは cairo が描画内容を出力する部分を抽
-象化しているからです。
+象化しているからです。  
 ![cairo-multi-output.png]({{base}}{{site.baseurl}}/images/0019-cairo/cairo-multi-output.png)
 
 これは Web アプリケーションでもデスクトップアプリケーションで
@@ -254,7 +254,7 @@ translate などといった描画関係の処理を変更する必要はあ
 cairo の欠点はなんといっても画像効果をサポートしていないこと
 でしょう。
 
-画像効果とは、「ぼかし」や「照明」といったものです。
+画像効果とは、「ぼかし」や「照明」といったものです。  
 ![blur.png]({{base}}{{site.baseurl}}/images/0019-cairo/blur.png)
 
 画像効果をサポートしていないと困る例をあげましょう。例えば、
@@ -272,7 +272,7 @@ Ruby から cairo を使うためには rcairo というライブラリを使う
 開発版の rcairo で実験的に「ぼかし」風の画像効果を実装していま
 す。実験的というだけあってうまく動かない場合もあるのですが、
 以下の実行例のようにアルファチャンネルがないものに対してはそ
-れっぽく動きます。ただ、動作は少し重いです。
+れっぽく動きます。ただ、動作は少し重いです。  
 ![pseudo-blur.png]({{base}}{{site.baseurl}}/images/0019-cairo/pseudo-blur.png)
 
 本稿では「ぼかし」風画像効果については扱いません。使いかたは
@@ -379,12 +379,12 @@ Cairo::Surface のサブクラスになっています。このようにたく�
 に立ちます (サーフェス用のコンテキスト作成)。画家にりんごを
 描いてくれるように頼みます (コンテキストに対する描画処理)。
 描き終わったら画家にお礼をいい、りんごが描かれたキャンバスを
-しまいます (サーフェスへ終了メッセージの送信)。
+しまいます (サーフェスへ終了メッセージの送信)。  
 ![surface-and-context.png]({{base}}{{site.baseurl}}/images/0019-cairo/surface-and-context.png)
 
 ### 例: 日の丸
 
-それでは、日の丸を描いてみましょう。出力結果はこうなります。
+それでは、日の丸を描いてみましょう。出力結果はこうなります。  
 ![hinomaru.png]({{base}}{{site.baseurl}}/images/0019-cairo/hinomaru.png)
 
 スクリプトは以下のようになります。
@@ -584,7 +584,7 @@ RGB/CMYK/HSV 間での相互変換が可能です。
 操作だけではなく、もう少し便利な四角形のパスを作る rectangle
 や丸を作る arc などがあります。cairo では提供していませんが、
 rcairo では角が丸まった四角形のパスを作る rounded_rectangle を
-用意しています。図は rectangle と rounded_rectangle の使用例です。
+用意しています。図は rectangle と rounded_rectangle の使用例です。  
 ![rectangle-and-rounded-rectangle.png]({{base}}{{site.baseurl}}/images/0019-cairo/rectangle-and-rounded-rectangle.png)
 
 日の丸の例では、まず、背景を真っ白に塗りつぶすために画像全体
@@ -683,7 +683,7 @@ fill はパスの内側を塗りつぶす操作で、stroke はパスに沿っ�
 
 fill も stroke もパスを描くとパスを消してしまいます。通常はこ
 の方が便利なのですが、パスが消されると困ることもあります。例
-えば、赤い四角を描いて、その周りを黒く縁どりしたい場合です。
+えば、赤い四角を描いて、その周りを黒く縁どりしたい場合です。  
 ![red-rectangle-with-black-border.png]({{base}}{{site.baseurl}}/images/0019-cairo/red-rectangle-with-black-border.png)
 
 この場合は fill_preserve と stroke_preserve を使います。
@@ -799,7 +799,7 @@ cairo を用いた画像の作成では、出力先を抽象化したサーフ�
 
 サーフェスを意識するのは、最初にサーフェスを作成するときと、
 最後にサーフェスから結果を取り出すときだけです。描画操作はコ
-ンテキストに対して行い、サーフェスを意識する必要はありません。
+ンテキストに対して行い、サーフェスを意識する必要はありません。  
 ![basic-conclusion.png]({{base}}{{site.baseurl}}/images/0019-cairo/basic-conclusion.png)
 
 描画操作でサーフェスを意識する必要がないということは、PNG 形
@@ -819,7 +819,7 @@ cairo を出力モジュールとして使っているライブラリがいく�
 を示します。
 
 これらのライブラリと連携すると、cairo と各描画ライブラリは図の
-ような関係になります。
+ような関係になります。  
 ![cairo-with-rendering-libraries.png]({{base}}{{site.baseurl}}/images/0019-cairo/cairo-with-rendering-libraries.png)
 
 ### svg2png.rb
@@ -1245,11 +1245,11 @@ Gdk::Pixbuf をコンテキストに描画する方法を説明する前に、�
 
 ソースはカーボン紙のようなものです。パスを描いたり塗りつぶし
 たりすると、ソースの内容がソースの下にあるサーフェスに描画さ
-れます。
+れます。  
 ![source-as-carbon-paper.png]({{base}}{{site.baseurl}}/images/0019-cairo/source-as-carbon-paper.png)
 
 しかし、普通のカーボン紙とは違って単色とは限りません。グラデー
-ションやサーフェスに描画した内容を使うことも出来ます。
+ションやサーフェスに描画した内容を使うことも出来ます。  
 ![several-sources.png]({{base}}{{site.baseurl}}/images/0019-cairo/several-sources.png)
 
 コンテキストはいつも必ず 1 つソースを持っています。今までは
@@ -1349,7 +1349,7 @@ close されるという関係と似ています。
 
 次は画像の描画方法をもう少し詳しく説明するための例です。前の
 例と似ていますが少しだけ違います。今度の例も画像を PDF に変換
-しますが、今度は画像に余白を付けて PDF に変換します。
+しますが、今度は画像に余白を付けて PDF に変換します。  
 ![image2pdf-with-margin-output.png]({{base}}{{site.baseurl}}/images/0019-cairo/image2pdf-with-margin-output.png)
 
 この例では左隅に画像を配置するのではなく、任意の場所に配置す
@@ -1407,7 +1407,7 @@ close されるという関係と似ています。
 る paint を呼ぶ前でもよさそうですが、それではうまくいきま
 せん。それはパスではなく、ソースをずらす必要があるからです。
 一方、画像の位置はそのままで、画像の一部だけを描画したい場合
-はパスをずらします。
+はパスをずらします。  
 ![translate-source-and-path.png]({{base}}{{site.baseurl}}/images/0019-cairo/translate-source-and-path.png)
 
 図では paint ではなく rectangle を使っていますが、これは paint は
@@ -1645,7 +1645,7 @@ poppler では PDF 文書がドキュメントオブジェクトに対応しま�
 
 あとは、各ページを縮小して描画するだけです。ただし、1 ページに
 縮小された複数のページを描画するため、各ページの描画位置を計
-算し、並んで描画するようにしなければいけません。
+算し、並んで描画するようにしなければいけません。  
 ![pdf-thumbnail-pages.png]({{base}}{{site.baseurl}}/images/0019-cairo/pdf-thumbnail-pages.png)
 
 描画位置を計算する部分は本質的ではないため、ここでは省略しま
@@ -1890,7 +1890,7 @@ Pango での指定のしかたはそれぞれ以下のようになります。
 {% endhighlight %}
 
 
-実行すると図のように「ex」の部分の背景色だけが緑色になります。
+実行すると図のように「ex」の部分の背景色だけが緑色になります。  
 ![pango-markup.png]({{base}}{{site.baseurl}}/images/0019-cairo/pango-markup.png)
 
 ### image-viewer.rb


### PR DESCRIPTION
今日は。

ふと「RailsでのPDF生成にcairoを使ったら速かったりするだろうか？」と思いついて、rcairoの使い方を知りたく、 https://magazine.rubyist.net/articles/0019/0019-cairo.html の記事に辿り着きました。昔の記事も残してくださっていてありがとうございます。

読みながら脚注リンクがうまく動いていないのに気が付いたので、修正しました。ついでに、これも併せて

* 脚注リンクの修正
* デッドリンクの修正
  * 殆どは現在有効なURIに差し替えましたが、Web 2.0 Graphicsというのだけ、懐かしのrubyforgeでホストされていたみたいで移行先を見付けられなかったので、Wayback Machineにリンクしました
* 画像のマークアップの修正
* コードブロックのハイライト

もやってみました。コミットを分けているので、運用方針と合わなければ捨ててください。

よければ取り込んでいただけると嬉しいです。
ご検討よろしくお願いします。