### PR TITLE
Use tag instead of path for post_url

### DIFF
--- a/articles/0063/_posts/2023-06-17-0063-ruby30thReport.md
+++ b/articles/0063/_posts/2023-06-17-0063-ruby30thReport.md
@@ -94,7 +94,7 @@ Ruby30 周年のイベントにあたって、まず、アンチハラスメン�
 
 Ruby on Rails が登場し Ruby のエコシステムに大きな変化をもたらします。
 
-2003 年に RubyForge.org が公開されました。その頃の様子は [シリーズ パッケージマネジメント 【第 1 回】 RubyGems (1)]({{base}}{% post_url articles/0006/_posts/2005-05-09-0006-PackageManagement %}) で垣間見ることができます。Ruby 標準のパッケージマネージャーがない中 Rails が RubyGems を採用していたことで、最終的には RubyGems が公式パッケージな位置付けとなりました。GitHub が Gem 専用のホストをしていましたが、2009 年に Gemcutter に移行します。 Gemcutter は 2010 年 3 月に RubyGems にリネームされます。 2010 年 9 月には Bundler もリリースされ、 RubyGems と Bundler でパッケージ管理が行われるようになりました。
+2003 年に RubyForge.org が公開されました。その頃の様子は [シリーズ パッケージマネジメント 【第 1 回】 RubyGems (1)]({{base}}{% post_url articles/0006/2005-05-09-0006-PackageManagement %}) で垣間見ることができます。Ruby 標準のパッケージマネージャーがない中 Rails が RubyGems を採用していたことで、最終的には RubyGems が公式パッケージな位置付けとなりました。GitHub が Gem 専用のホストをしていましたが、2009 年に Gemcutter に移行します。 Gemcutter は 2010 年 3 月に RubyGems にリネームされます。 2010 年 9 月には Bundler もリリースされ、 RubyGems と Bundler でパッケージ管理が行われるようになりました。
 
 その頃 Merb が取り込まれたバージョンである Rails 3.0 が公開されました。Rails は多くのライブラリを巻き込んで動かすため、パッケージ管理に与えた影響が大きかったのだろうと思います。Rails の開発とともに Ruby のエコシステムも構築されていきました。
 


### PR DESCRIPTION
現masterのコードだとビルド時にDeprecationがでているので、その修正です。
あまりjekyllに詳しくないですがおそらくこのような修正でよさそう。

## Before

```
$ bundle exec jekyll build
Configuration file: /Users/hogelog/repos/oss/ruby/magazine.rubyist.net/_config.yml
            Source: /Users/hogelog/repos/oss/ruby/magazine.rubyist.net
       Destination: /Users/hogelog/repos/oss/ruby/magazine.rubyist.net/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
       Deprecation: A call to '{% post_url articles/0006/_posts/2005-05-09-0006-PackageManagement %}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly.
                    done in 9.573 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```

## After
```
$ bundle exec jekyll build
Configuration file: /Users/hogelog/repos/oss/ruby/magazine.rubyist.net/_config.yml
            Source: /Users/hogelog/repos/oss/ruby/magazine.rubyist.net
       Destination: /Users/hogelog/repos/oss/ruby/magazine.rubyist.net/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 6.82 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```

![image](https://github.com/rubima/magazine.rubyist.net/assets/50920/4df276c8-6f68-4593-80d6-a3c9707d87b5)

ローカルでの動作確認の様子。適切にリンクされてそうです。