### PR TITLE
Rubyの会の公式WikiのURLを修正

### DIFF
--- a/articles/0036/_posts/2011-11-28-0036-index.md
+++ b/articles/0036/_posts/2011-11-28-0036-index.md
@@ -61,9 +61,9 @@ Ruby をはじめるにあたって必要な情報をご紹介します。本稿
 
 0032 号から休載が続いていた RubyNews は復活を求める熱いお便りが届くこともなかったので、いったん終了とすることにします。また、Rubyist のうれしいニュースの形が浮かんだ人がいればあらたな形で復活するかもしれません。RubyNews 先生の次回作にご期待ください。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0036 号 編集後記]({{base}}{% post_url articles/0036/2011-11-28-0036-EditorsNote %})
 

--- a/articles/0037/_posts/2012-02-05-0037-index.md
+++ b/articles/0037/_posts/2012-02-05-0037-index.md
@@ -68,9 +68,9 @@ Ruby ではない言語をよく知る著者が Ruby との違いや共通点を
 
 2011 年 12 月に栃木で開催された とちぎ Ruby 会議 04 の報告です。(難易度：いろいろ)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0037 号 編集後記]({{base}}{% post_url articles/0037/2012-02-05-0037-EditorsNote %})
 

--- a/articles/0038/_posts/2012-05-22-0038-index.md
+++ b/articles/0038/_posts/2012-05-22-0038-index.md
@@ -54,9 +54,9 @@ Rubyist なら誰でも聞かれる「あなたは map 派？それとも collec
 
 ワークスコーポレーション様のご提供により、『―Ruby on Rails 3 で作る― jpmobile によるモバイルサイト構築』を Rubyist Magazine 読者の方にプレゼントします。 (難易度：当)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0038 号 編集後記]({{base}}{% post_url articles/0038/2012-05-22-0038-EditorsNote %})
 

--- a/articles/0039/_posts/2012-09-05-0039-index.md
+++ b/articles/0039/_posts/2012-09-05-0039-index.md
@@ -72,9 +72,9 @@ Ruby ではあまり意識されることのない「式と文」の違いにつ
 
 技術評論社様のご提供により、『たのしい開発 スタートアップRuby』を Rubyist Magazine 読者の方にプレゼントします。 (難易度：当)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0039 号 編集後記]({{base}}{% post_url articles/0039/2012-09-05-0039-EditorsNote %})
 

--- a/articles/0040/_posts/2012-11-25-0040-index.md
+++ b/articles/0040/_posts/2012-11-25-0040-index.md
@@ -52,9 +52,9 @@ Ruby をはじめるにあたって必要な情報をご紹介します。本稿
 
 2012 年 9 月に札幌で開催された札幌 Ruby 会議 2012 の報告です。(難易度：いろいろ)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0040 号 編集後記]({{base}}{% post_url articles/0040/2012-11-25-0040-EditorsNote %})
 

--- a/articles/0041/_posts/2013-02-24-0041-index.md
+++ b/articles/0041/_posts/2013-02-24-0041-index.md
@@ -122,9 +122,9 @@ YARV: Yet Another RubyVM を解説する連載の久しぶりの掲載。今回�
 
 Ruby をはじめるにあたって必要な情報をご紹介します。本稿は Rubyist Magazine 常設記事です。(難易度：低)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0041 号 編集後記]({{base}}{% post_url articles/0041/2013-02-24-0041-EditorsNote %})
 

--- a/articles/0042/_posts/2013-05-29-0042-index.md
+++ b/articles/0042/_posts/2013-05-29-0042-index.md
@@ -80,9 +80,9 @@ Cucumber に代わるエンドツーエンドテスト自動化ツール Turnip 
 
 るびまのサーバ移行により、Ruby や Hiki のバージョンアップを行うことができました。本稿は移行プロジェクトがなぜ実施されたのか、どのように進められたのかを紹介し、移行に関わった人への感謝を記します。 (難易度：易)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0042 号 編集後記]({{base}}{% post_url articles/0042/2013-05-29-0042-EditorsNote %})
 

--- a/articles/0043/_posts/2013-07-31-0043-EuRuKo2013.md
+++ b/articles/0043/_posts/2013-07-31-0043-EuRuKo2013.md
@@ -254,7 +254,7 @@ Asakusa.rb では国内・海外問わずこうした Ruby のカンファレン
 
 プログラミング言語 Ruby は、なぜだかとてもコミュニティ活動が盛んで、世界中に Ruby コミュニティやコミュニティ主催のカンファレンスがあります。日本からもっとたくさんの Rubyist が海外の Ruby カンファレンスに参加して、海外の Ruby コミュニティとの交流が増えていくと素敵だなあと思っています。
 
-今年の 11 月には [RubyConf 2013](http://rubyconf.org/) がアメリカのフロリダ州マイアミにて開催されます。[日本 Ruby の会](http://ruby-no-kai.org/)では[渡航支援プログラムが組まれる予定](https://github.com/ruby-no-kai/official/wiki/RubyConf2013SupportProgram)ですので、我こそはと思う人は積極的に利用されることをお勧めいたします。
+今年の 11 月には [RubyConf 2013](http://rubyconf.org/) がアメリカのフロリダ州マイアミにて開催されます。[日本 Ruby の会](http://ruby-no-kai.org/)では[渡航支援プログラムが組まれる予定](https://cosen.se/ruby-no-kai/%E6%97%A5%E6%9C%AC%E5%9B%BD%E5%A4%96%E3%81%AERuby%E3%82%AB%E3%83%B3%E3%83%95%E3%82%A1%E3%83%AC%E3%83%B3%E3%82%B9%E3%81%B8%E3%81%AE%E5%8F%82%E5%8A%A0%E6%B8%A1%E8%88%AA%E8%B2%BB%E6%94%AF%E6%8F%B4)ですので、我こそはと思う人は積極的に利用されることをお勧めいたします。
 
 そして RubyKaigi に外国からやって来た人を見かけたり、あなたの所属する Ruby コミュニティに外国から人が来たりした時は、ぜひ積極的に声をかけ、温かく迎え入れてあげてください。
 

--- a/articles/0043/_posts/2013-07-31-0043-RubyKaigi2013.md
+++ b/articles/0043/_posts/2013-07-31-0043-RubyKaigi2013.md
@@ -603,7 +603,7 @@ RubyKaigi とても刺激的でした。スライドや動画からは伝わら�
 ----
 
 [^1]: [Ruby - Wikipedia](http://ja.wikipedia.org/wiki/Ruby) などで "まつもとの同僚の誕生石（7 月）のルビーを取って名付けられた" として言及されている「同僚」本人でもあります
-[^2]: 当時の言語名の正式な表記は、すべて小文字の「ruby」でした。ただし、 [[ruby-list:5039] Ruby or ruby, but no RUBY](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/5039) 以後は「Ruby」と表記することが許容され、現在では言語の正式表記は「Ruby」になっています。 ["Ruby" と "ruby" はどっちが正しいのですか](https://github.com/ruby-no-kai/official/wiki/Ruby-FAQ#ruby%E3%81%A8ruby%E3%81%AF%E3%81%A9%E3%81%A3%E3%81%A1%E3%81%8C%E6%AD%A3%E3%81%97%E3%81%84%E3%81%AE%E3%81%A7%E3%81%99%E3%81%8B) も参照
+[^2]: 当時の言語名の正式な表記は、すべて小文字の「ruby」でした。ただし、 [[ruby-list:5039] Ruby or ruby, but no RUBY](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/5039) 以後は「Ruby」と表記することが許容され、現在では言語の正式表記は「Ruby」になっています。 ["Ruby" と "ruby" はどっちが正しいのですか](https://cosen.se/ruby-no-kai/Ruby_FAQ#640e51d5686daf00004b8b05) も参照
 [^3]: Ruby では多重継承をサポートしないが、その代替としてモジュールの Mix-in をサポートする。継承の種類と特徴については、まつもとさんの書かれた [まつもと直伝 プログラミングのオキテ](http://itpro.nikkeibp.co.jp/article/COLUMN/20060825/246409/) の「第3回 多重継承の光と影」を参照
 [^4]: 「Transcendental Ruby Imbroglio Contest for rubyKaigi (超絶技巧 Ruby 意味不明コンテスト in RubyKaigi)」の頭文字
 [^5]: ここでは難解で突拍子もない発想と、周囲を置いてきぼりにする異次元な実力のことを、最高の賛辞を添えて「変態」と表現しています

--- a/articles/0043/_posts/2013-07-31-0043-index.md
+++ b/articles/0043/_posts/2013-07-31-0043-index.md
@@ -82,9 +82,9 @@ RubyMotion は Ruby で iOS アプリケーションを作るための仕組み�
 
 2013 年 8 月に発売されるパーフェクトシリーズの Ruby 本「パーフェクト Ruby」の紹介です。(難易度：完全無欠)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0043 号 編集後記]({{base}}{% post_url articles/0043/2013-07-31-0043-EditorsNote %})
 

--- a/articles/0044/_posts/2013-09-30-0044-EditorComment.md
+++ b/articles/0044/_posts/2013-09-30-0044-EditorComment.md
@@ -71,7 +71,7 @@ tags: 0044 EditorComment
 * [YARV Maniacs 【第 11 回】 最近の YARV の事情]({{base}}{% post_url articles/0041/2013-02-24-0041-YarvManiacs %})
 
 
-そしてシリーズ物としては毎号掲載されている「Regional RubyKaigi レポート」。岡山 Ruby 会議が 2 回開催されているのを始めとして、北は北海道から南は九州まで、各地の Ruby コミュニティによる地域 Ruby 会議が活発に開催されていることが分かりますね。こうしたレポートを見て興味を持ったら、ぜひ各地域の地域 Ruby 会議に足を運んでみてください。地域 Ruby 会議の開催予定は「[地域Ruby会議のサイト](http://regional.rubykaigi.org/)」や「[RubyKaigi 日記](http://rubykaigi.tdiary.net/)」、「[これから開催される地域Ruby会議](https://github.com/ruby-no-kai/official/wiki/Upcomingregionalrubykaigi)」といったサイトをチェックしてみてください。
+そしてシリーズ物としては毎号掲載されている「Regional RubyKaigi レポート」。岡山 Ruby 会議が 2 回開催されているのを始めとして、北は北海道から南は九州まで、各地の Ruby コミュニティによる地域 Ruby 会議が活発に開催されていることが分かりますね。こうしたレポートを見て興味を持ったら、ぜひ各地域の地域 Ruby 会議に足を運んでみてください。地域 Ruby 会議の開催予定は「[地域Ruby会議のサイト](http://regional.rubykaigi.org/)」や「[RubyKaigi 日記](http://rubykaigi.tdiary.net/)」、「[RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)」といったサイトをチェックしてみてください。
 
 * [RegionalRubyKaigi レポート (30) 岡山 Ruby 会議 01]({{base}}{% post_url articles/0040/2012-11-25-0040-OkayamaRubyKaigi01Report %})
 * [RegionalRubyKaigi レポート (31) 松江 Ruby 会議 04]({{base}}{% post_url articles/0040/2012-11-25-0040-MatsueRubyKaigi04Report %})
@@ -90,7 +90,7 @@ tags: 0044 EditorComment
 
 かねてより日本の Ruby コミュニティと海外の Ruby コミュニティとの断絶の話は何度も話題に上っており、日本の Ruby コミュニティはもっともっと海外の Ruby コミュニティと交流が必要だと個人的には思っていますので、こうした記事を読んで興味を持ったらぜひ海外の Ruby カンファレンスへも足を運んでみてください。また海外に行くのが無理という方も、日本国内で海外の著名な Rubyist が講演するイベントも最近は増えてきましたので、そうした機会を見つけてぜひ海外の Rubyist と交流してみてください。
 
-国内および海外の Ruby カンファレンスの開催情報については、[RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck) をご参照ください。
+国内および海外の Ruby カンファレンスの開催情報については、[RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck) をご参照ください。
 
 * [レポートチーム史上最大の作戦]({{base}}{% post_url articles/0040/2012-11-25-0040-HowToBuildSprk2012ReportTeam %})
 * [Euroko 2012 参加レポート]({{base}}{% post_url articles/0041/2013-02-24-0041-Euroko2012 %})

--- a/articles/0044/_posts/2013-09-30-0044-index.md
+++ b/articles/0044/_posts/2013-09-30-0044-index.md
@@ -70,9 +70,9 @@ Rubyist へのインタビュー企画。今回は大場さん夫妻にお話を
 
 44号から直近1ヶ月間のるびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0044 号 編集後記]({{base}}{% post_url articles/0044/2013-09-30-0044-EditorsNote %})
 

--- a/articles/0045/_posts/2013-12-21-0045-index.md
+++ b/articles/0045/_posts/2013-12-21-0045-index.md
@@ -66,9 +66,9 @@ RubyConf2013 の参加レポートです。 (難易度：マイアミ)
 
 45 号から直近 1 ヶ月間のるびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0045 号 編集後記](0045 号 編集後記)
 

--- a/articles/0046/_posts/2014-04-05-0046-index.md
+++ b/articles/0046/_posts/2014-04-05-0046-index.md
@@ -58,9 +58,9 @@ yhara 様のご提供により、『Rubyで作る奇妙なプログラミング�
 
 46 号から直近 1 ヶ月間のるびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0046 号 編集後記](0046 号 編集後記)
 

--- a/articles/0047/_posts/2014-06-30-0047-index.md
+++ b/articles/0047/_posts/2014-06-30-0047-index.md
@@ -62,9 +62,9 @@ Ruby の内部 DSL を使って NES エミュレータ向けアプリケーシ�
 
 47 号から直近 1 ヶ月間のるびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0047 号 編集後記](0047 号 編集後記)
 

--- a/articles/0048/_posts/2014-09-19-0048-EditorComment.md
+++ b/articles/0048/_posts/2014-09-19-0048-EditorComment.md
@@ -69,7 +69,7 @@ Rubyist Magazine 常設記事の「Ruby の歩き方」ですが、昨年大幅�
 * [RubyConf 台湾 2014 参加・発表レポート]({{base}}{% post_url articles/0047/2014-06-30-0047-RubyConfTw2014 %})
 
 
-こうして国内・海外で多数の Ruby 関連カンファレンスが開催されていますので、ご興味のある方はぜひ足を運んでみてください。地域 Ruby 会議の開催予定は「[地域Ruby会議のサイト](http://regional.rubykaigi.org/)」や「[RubyKaigi 日記](http://rubykaigi.tdiary.net/)」、「[これから開催される地域Ruby会議](https://github.com/ruby-no-kai/official/wiki/Upcomingregionalrubykaigi)」といったサイトを、海外の Ruby カンファレンスの開催予定は [Lanyrd の Ruby conferences and events](http://lanyrd.com/topics/ruby/) などのサイトをチェックしてみてください。
+こうして国内・海外で多数の Ruby 関連カンファレンスが開催されていますので、ご興味のある方はぜひ足を運んでみてください。地域 Ruby 会議の開催予定は「[地域Ruby会議のサイト](http://regional.rubykaigi.org/)」や「[RubyKaigi 日記](http://rubykaigi.tdiary.net/)」、「[RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)」といったサイトを、海外の Ruby カンファレンスの開催予定は [Lanyrd の Ruby conferences and events](http://lanyrd.com/topics/ruby/) などのサイトをチェックしてみてください。
 
 個別記事は次のとおりです。
 

--- a/articles/0048/_posts/2014-09-19-0048-index.md
+++ b/articles/0048/_posts/2014-09-19-0048-index.md
@@ -58,9 +58,9 @@ Ruby 2.2 に入れたいと思っているインクリメンタル GC につい�
 
 48 号から直近 1 ヶ月間のるびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0048 号 編集後記]({{base}}{% post_url articles/0048/2014-09-19-0048-EditorsNote %})
 

--- a/articles/0049/_posts/2014-12-14-0049-index.md
+++ b/articles/0049/_posts/2014-12-14-0049-index.md
@@ -59,9 +59,9 @@ Ruby の最新の実装を紹介する Ruby Under a Microscope の翻訳、
 
 49 号から直近 1 ヶ月間のるびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0049 号 編集後記]({{base}}{% post_url articles/0049/2014-12-14-0049-EditorsNote %})
 

--- a/articles/0050/_posts/2015-05-10-0050-index.md
+++ b/articles/0050/_posts/2015-05-10-0050-index.md
@@ -85,9 +85,9 @@ RubyKaigi 2014 での川村さんの発表「[Hypermedia: the Missing Element to
 
 0049 号リリース時点から 0050 号リリース直前までの、るびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0050 号 編集後記]({{base}}{% post_url articles/0050/2015-05-10-0050-EditorsNote %})
 

--- a/articles/0051/_posts/2015-09-06-0051-index.md
+++ b/articles/0051/_posts/2015-09-06-0051-index.md
@@ -74,9 +74,9 @@ Ruby on Rails で認証機能を作るための gem の一つである Monban �
 
 0050 号リリース時点から 0051 号リリース直前までの、るびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0051 号 編集後記]({{base}}{% post_url articles/0051/2015-09-06-0051-EditorsNote %})
 

--- a/articles/0052/_posts/2015-12-06-0052-index.md
+++ b/articles/0052/_posts/2015-12-06-0052-index.md
@@ -52,9 +52,9 @@ esa.io の裏側の紹介記事です。（難易度：(\\( ⁰⊖⁰)/)）
 
 0050 号でのプレゼント当選者から感想をブログに記していただきましたので、ご紹介します。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0052 号 編集後記]({{base}}{% post_url articles/0052/2015-12-06-0052-EditorsNote %})
 

--- a/articles/0053/_posts/2016-04-03-0053-index.md
+++ b/articles/0053/_posts/2016-04-03-0053-index.md
@@ -52,9 +52,9 @@ RubyKaigi 2015 で発表した Compiling Ruby scripts という発表の話で�
 
 0052 号リリース時点から 0053 号リリース直前までの、るびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0053 号 読者プレゼント]({{base}}{% post_url articles/0053/2016-04-03-0053-Present %})
 

--- a/articles/0054/_posts/2016-08-21-0054-TokyoRubyKaigi11Report.md
+++ b/articles/0054/_posts/2016-08-21-0054-TokyoRubyKaigi11Report.md
@@ -380,7 +380,7 @@ Distributed task execution を行うためには、DAG で表されたタスク�
 ## まとめ
 
 ![IMG_4442.jpg]({{base}}{{site.baseurl}}/images/0054-TokyoRubyKaigi11Report/IMG_4442.jpg)
-さて、血湧き肉躍るハックのいちにちはいかがだったでしょうか？「[技術的好奇心を改めて呼び起こし、プログラミングの難しさ、そして楽しさを再発見する](http://regional.rubykaigi.org/tokyo11/about/)」ことができたように思います。笹田さんからの「われこそは、という人は次回やってみましょう」という呼びかけで、東京 Ruby 会議 11 は閉幕しました。興味の出た方は、とりあえず、日本 Ruby の会の Wiki の [RegionalRubyKaigiのページ](https://github.com/ruby-no-kai/official/wiki/Regionalrubykaigi) を見てみてください。
+さて、血湧き肉躍るハックのいちにちはいかがだったでしょうか？「[技術的好奇心を改めて呼び起こし、プログラミングの難しさ、そして楽しさを再発見する](http://regional.rubykaigi.org/tokyo11/about/)」ことができたように思います。笹田さんからの「われこそは、という人は次回やってみましょう」という呼びかけで、東京 Ruby 会議 11 は閉幕しました。興味の出た方は、とりあえず、日本 Ruby の会の Wiki の [RegionalRubyKaigiのページ](https://cosen.se/ruby-no-kai/Regional_RubyKaigi) を見てみてください。
 
 ## 執筆者
 

--- a/articles/0054/_posts/2016-08-21-0054-index.md
+++ b/articles/0054/_posts/2016-08-21-0054-index.md
@@ -69,9 +69,9 @@ Ruby をはじめるにあたって必要な情報をご紹介します。本稿
 
 0053 号リリース時点から 0054 号リリース直前までの、るびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0054 号 編集後記]({{base}}{% post_url articles/0054/2016-08-21-0054-EditorsNote %})
 

--- a/articles/0055/_posts/2017-03-26-0055-index.md
+++ b/articles/0055/_posts/2017-03-26-0055-index.md
@@ -50,9 +50,9 @@ RubyKaigi 2016 で開設した託児所の運営記録です。(難易度：子�
 
 0054 号リリース時点から 0055 号リリース直前までの、るびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0055 号 編集後記]({{base}}{% post_url articles/0055/2017-03-26-0055-EditorsNote %})
 

--- a/articles/0056/_posts/2017-08-27-0056-index.md
+++ b/articles/0056/_posts/2017-08-27-0056-index.md
@@ -56,9 +56,9 @@ Erlang プロセスとそれを利用したプログラミングを Ruby に少�
 
 0055 号リリース時点から 0056 号リリース直前までの、るびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0056 号 編集後記]({{base}}{% post_url articles/0056/2017-08-27-0056-EditorsNote %})
 

--- a/articles/0057/_posts/2018-02-11-0057-index.md
+++ b/articles/0057/_posts/2018-02-11-0057-index.md
@@ -55,9 +55,9 @@ Ruby を使ってゲーム作成に挑戦！　Ruby 学習へのとっかかり�
 
 0056 号リリース時点から 0057 号リリース直前までの、るびまの記事のアクセスランキングです。
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0057 号 編集後記]({{base}}{% post_url articles/0057/2018-02-11-0057-EditorsNote %})
 

--- a/articles/0058/_posts/2018-08-26-0058-index.md
+++ b/articles/0058/_posts/2018-08-26-0058-index.md
@@ -43,9 +43,9 @@ Rubyist へのインタビュー企画。今回は村田賢太さんにお話を
 
 るびまのバージョンアップの内容を記した記事です。(難易度：中)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0058 号 編集後記]({{base}}{% post_url articles/0058/2018-08-26-0058-EditorsNote %})
 

--- a/articles/0059/_posts/2019-01-27-0059-index.md
+++ b/articles/0059/_posts/2019-01-27-0059-index.md
@@ -74,9 +74,9 @@ RubyそしてRailsをこれから勉強したい方に、どんな技術を勉�
 
 2018年11月2日（金）と3日（土）に開催された Rails Girls Sendai 1st のレポート記事です。(難易度：低)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0059 号 編集後記]({{base}}{% post_url articles/0059/2019-01-27-0059-EditorsNote %})
 

--- a/articles/0060/_posts/2019-08-18-0060-index.md
+++ b/articles/0060/_posts/2019-08-18-0060-index.md
@@ -86,9 +86,9 @@ Mastodon BotをAWS Lambdaを使って実装する解説記事です。(難易度
 
 2019年8月2日（金）と3日（土）に開催された Rails Girls Tokyo 12th のレポート記事です。(難易度：低)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0060 号 編集後記]({{base}}{% post_url articles/0060/2019-08-18-0060-EditorsNote %})
 

--- a/articles/0061/_posts/2020-02-02-0061-index.md
+++ b/articles/0061/_posts/2020-02-02-0061-index.md
@@ -54,9 +54,9 @@ Rubyist へのインタビュー企画。今回は国分崇志さんにお話を
 
 2019 年 12 月に開催された 平成 Ruby 会議 01 のレポート記事です。(難易度：低)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0061 号 編集後記]({{base}}{% post_url articles/0061/2020-02-02-0061-EditorsNote %})
 

--- a/articles/0063/_posts/2024-01-08-0063-index.md
+++ b/articles/0063/_posts/2024-01-08-0063-index.md
@@ -70,9 +70,9 @@ heronshoes さんが、2022 年度の Ruby アソシエーション開発助成�
 
 2023 年 5 月 3 日に出版された『はじめてつくる Web アプリケーション〜 Ruby on Rails でプログラミングへの第一歩を踏み出そう』の訳者による紹介です。  (難易度：低)
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0063 号 編集後記]({{base}}{%  post_url articles/0063/2024-01-08-0063-EditorsNote %})
 

--- a/articles/first_step_ruby/_posts/2000-01-01-FirstStepRuby.md
+++ b/articles/first_step_ruby/_posts/2000-01-01-FirstStepRuby.md
@@ -180,7 +180,7 @@ Ruby はコミュニティ活動が非常に活発です。
 
 勉強会やコミュニティに参加するようになると、新しい情報や実務に基づいた詳しい情報なども入手することができるようになります。
 
-まずは [地域Rubyの会](https://github.com/ruby-no-kai/official/wiki/RegionalRubyistMeetUp) を探してみるといいと思います。
+まずは [ruby-jp](https://cosen.se/ruby-jp/)の[地域.rbのページ](https://cosen.se/ruby-jp/%E5%9C%B0%E5%9F%9F.rb) を探してみるといいと思います。
 
 
 ## おわりに

--- a/editing_tools/template/index.md.erb
+++ b/editing_tools/template/index.md.erb
@@ -31,9 +31,9 @@ TODO: 一言書く (難易度：X)
 
 <% end %>
 
-### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://github.com/ruby-no-kai/official/wiki/RubyEventCheck)
+### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [RubyEventCheck](https://cosen.se/ruby-no-kai/RubyEventCheck)
 
-Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://github.com/ruby-no-kai/official/wiki) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
+Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は [日本 Ruby の会 公式 Wiki](https://cosen.se/ruby-no-kai/) にて常時更新されている同名ページへのリンクとなります。(難易度：低)
 
 ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [0060 号 編集後記]({{base}}{% post_url articles/0060/2019-08-18-0060-EditorsNote %})
 


### PR DESCRIPTION
ref #508 

Rubyの会の公式WikiをGitHub WikiからCosense(旧Scrapbox)に移転したのに伴い、関連URLを修正しました。
地域Rubyコミュニティへの参照先については、[/ruby-no-kai/地域.rb](https://scrapbox.io/ruby-no-kai/%E5%9C%B0%E5%9F%9F.rb) よりも [/ruby-jp/地域.rb](https://scrapbox.io/ruby-jp/%E5%9C%B0%E5%9F%9F.rb) にした方が有用に思えたので、そこだけ参照先を変更しています。