### PR TITLE
Link to issue

### DIFF
--- a/articles/0064/_posts/2024-05-28-RubyKaigi2024Report.md
+++ b/articles/0064/_posts/2024-05-28-RubyKaigi2024Report.md
@@ -260,7 +260,7 @@ created_on: 2024-05-28
 
 ## さいごに
 
-載せきれなかった写真は issue にあります。合わせてご覧ください。
-https://github.com/rubima/magazine.rubyist.net/issues/500
+載せきれなかった写真は issue にあります。合わせてご覧ください。  
+<https://github.com/rubima/magazine.rubyist.net/issues/500>
 
 次回の RubyKaigi も楽しみですね。


### PR DESCRIPTION
RubyKaigi 2024 フォトレポート https://magazine.rubyist.net/articles/0064/RubyKaigi2024Report.html の記事ですが、記事末尾のIssue URLがリンクになっていなかったので。

## Before

![image](https://github.com/user-attachments/assets/6de19db0-c3dd-4f70-b2dc-8b366c0e1f39)


## After

![image](https://github.com/user-attachments/assets/729542da-bc62-4c69-a5c3-89926eb78871)

リンクになるようにしたのと、おそらく改行されてほしいのかなと考えて改行も入れましたがどうでしょう