### PR TITLE
Fix title formatting in OkinawaRubyKaigi02 report

### DIFF
--- a/articles/0059/_posts/2019-01-27-0059-OkinawaRubyKaigi02Report.md
+++ b/articles/0059/_posts/2019-01-27-0059-OkinawaRubyKaigi02Report.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: RegionalRubyKaigi レポート (70) 沖縄　ruby 会議 02
+title: RegionalRubyKaigi レポート (70) 沖縄 Ruby 会議 02
 short_title: RegionalRubyKaigi レポート (70) 沖縄 Ruby 会議 02
 tags: 0059 OkinawaRubyKaigi02Report regionalRubyKaigi
 post_author: kousy, 仲座 李香, 島袋 雄太


### PR DESCRIPTION
たまたま見かけたのですが、沖縄Ruby会議02の沖縄の後のスペースが全角になっていたのと、[r]ubyになっていたのを修正しました。

![image](https://github.com/user-attachments/assets/931400a9-d8e7-4877-ad39-71eb35fa128a)
