### PR TITLE
Fix: Font Awesome v6.6.0にアップグレードとTwitterからXに変更する

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
   <link href="{{base}}{{ site.baseurl }}/css/theme.css" rel="stylesheet" type="text/css">
   <link href="{{base}}{{ site.baseurl }}/css/syntax.css" rel="stylesheet" type="text/css">
   <link href="{{base}}{{ site.baseurl }}/css/sharebutton.css" rel="stylesheet" type="text/css">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+  <link href="https://use.fontawesome.com/releases/v6.6.0/css/all.css" rel="stylesheet">
 
   <link rel="canonical" href="{{ page.url  | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/index_head.html
+++ b/_includes/index_head.html
@@ -22,7 +22,7 @@
   <link href="{{base}}{{ site.baseurl }}/css/theme.css" rel="stylesheet" type="text/css">
   <link href="{{base}}{{ site.baseurl }}/css/syntax.css" rel="stylesheet" type="text/css">
   <link href="{{base}}{{ site.baseurl }}/css/sharebutton.css" rel="stylesheet" type="text/css">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+  <link href="https://use.fontawesome.com/releases/v6.6.0/css/all.css" rel="stylesheet">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/social-buttons.html
+++ b/_includes/social-buttons.html
@@ -1,7 +1,7 @@
 <div class='sns'>            
     <ul class="clearfix">
-       <li class="twitter"><a href="https://twitter.com/share?text={{ page.title }}&amp;url={{ site.url }}{{ site.baseurl }}{{ page.url }}" target="_blank" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=300,width=600');return false;"><i class="fa fa-twitter"></i></a></li>
-       <li class="facebook"><a href="https://www.facebook.com/sharer.php?u={{ site.url }}{{ site.baseurl }}{{ page.url }}&amp;t={{ page.title }}" target="_blank" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=300,width=600');return false;"><i class="fa fa-facebook"></i></a></li>
+       <li class="twitter-x"><a href="https://x.com/share?text={{ page.title }}&amp;url={{ site.url }}{{ site.baseurl }}{{ page.url }}" target="_blank" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=300,width=600');return false;"><i class="fa fa-brands fa-x-twitter"></i></a></li>
+       <li class="facebook"><a href="https://www.facebook.com/sharer.php?u={{ site.url }}{{ site.baseurl }}{{ page.url }}&amp;t={{ page.title }}" target="_blank" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=300,width=600');return false;"><i class="fa fa-brands fa-facebook-f"></i></a></li>
        <li class="hatebu"><a href="http://b.hatena.ne.jp/add?mode=confirm&amp;url={{ site.url }}{{ site.baseurl }}{{ page.url }}&amp;{{ page.title }}" target="_blank" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=300,width=600');return false;"><i class="fa">B!</i></a></li>
     </ul>
 </div>

--- a/css/sharebutton.css
+++ b/css/sharebutton.css
@@ -26,13 +26,13 @@
     text-decoration: none;
   }
   /* ツイッター */
-   .twitter a {
-     color:#00acee;
+   .twitter-x a {
+     color:#000000;
       background:#fff;
-      border:2px solid #00acee
+      border:2px solid #000000
   }
-    .twitter a:hover {
-      background:#00acee;
+    .twitter-x a:hover {
+      background:#000000;
      color:#fff;
   }
   /* Facebook */


### PR DESCRIPTION
Issue: https://github.com/rubima/magazine.rubyist.net/issues/539

Xアイコンを使えるために、Font Awesome v6.6.0にアップグレードするべき

変更する前：

<img width="1384" alt="Screenshot 2024-10-30 at 16 45 31" src="https://github.com/user-attachments/assets/b0a0324e-58f6-41d7-b298-786d2cdcacf5">

変更する後：

<img width="1384" alt="Screenshot 2024-10-30 at 16 43 21" src="https://github.com/user-attachments/assets/17e6fe9d-0367-4daa-a880-0a5ba6abed82">
