### PR TITLE
YouTubeの埋め込みが表示されるようにした

### DIFF
--- a/articles/0042/_posts/2013-05-29-0042-FollowUpKirishimaRuby.md
+++ b/articles/0042/_posts/2013-05-29-0042-FollowUpKirishimaRuby.md
@@ -37,7 +37,8 @@ tags: 0042 FollowUpKirishimaRuby
 昔はよくプログラミングしてたんだけど、最近は Excel とか Word ばっかり相手にして、あんまりプログラミングしてない人はまたプログラミングをはじめるきっかけになると嬉しいですし、現在、たくさんプログラミングをしている人はプログラミングとの向き合いを考えるきっかけになると嬉しいです。
 
 ## 『桐島、部活やめるってよ』
-<object width="560" height="315"><param name="movie" value="http://www.youtube.com/v/KjjG0WTQ6C4" /><embed src="http://www.youtube.com/v/KjjG0WTQ6C4" type="application/x-shockwave-flash" width="560" height="315" /></object>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/KjjG0WTQ6C4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 最近、映画鑑賞が趣味でいろんな映画を観ていて、その中でも昨年公開された『[桐島、部活やめるってよ](http://www.kirishima-movie.com/)』がかなりお気に入りです。
 映画『桐島』っていうのはあまり多くを語らない映画といいますか、ぽっかりと空洞がある映画で、自分の想像で補う部分が非常に大きい作品だと考えています。
@@ -165,7 +166,8 @@ tags: 0042 FollowUpKirishimaRuby
 そんなみなさんを納得させるため、ここからは具体的なぽんこつ事例を挙げていき、自分のぽんこつ度の検証していこうと思います。
 
 一つ目の事例はみなさん大好き Perfume に関するものです。私自身は Perfume に関してそれほど思い入れがあるわけでもないのですが、Perfume が [perfume-dev](http://perfume-dev.github.io/) という面白い取り組みをしていたのに興味を持ちました。
-<object width="560" height="315"><param name="movie" value="http://www.youtube.com/v/uIgsODaANHY" /><embed src="http://www.youtube.com/v/uIgsODaANHY" type="application/x-shockwave-flash" width="560" height="315" /></object>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/uIgsODaANHY?si=PkaCKGqRcVixCgAj" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 Perfume は彼女たちのダンスなどのモーションデータと音声データを github 上に[公開しました](https://github.com/perfume-dev)。
 このデータを使って世界中のクリエータたちにデータを基にして自由に作品を作ってもらい、Perfume 自身の世界的な知名度をあげようというのが perfume-dev の狙いのようです。
@@ -177,7 +179,8 @@ Perfume は彼女たちのダンスなどのモーションデータと音声デ
 モーションデータは[BVH形式](http://www.tmps.org/?MOCAP%A5%C7%A1%BC%A5%BF%A5%D5%A5%A1%A5%A4%A5%EB)でデータが公開されており、まずはこれをパースする必要がありましたが、運良く gem があったのでそれを使うことにしました。
 
 そして、お盆休みに徹夜してプログラムを書き、ついに Perfume を踊らせることに成功したのです！　わーい、できた〜！
-<object width="560" height="315"><param name="movie" value="http://www.youtube.com/v/rjoFPGmJyn0" /><embed src="http://www.youtube.com/v/rjoFPGmJyn0" type="application/x-shockwave-flash" width="560" height="315" /></object>
+
+<iframe width="560" height="315" src="http://www.youtube.com/embed/rjoFPGmJyn0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 徹夜して寝ぼけてたので「Perfume もずいぶん近未来的というか、アグレッシブな関節の使い方するんだな」とマジで誤解して、Youtube に上記の動画の上げて寝ました。
 この動画には次のような反響がありました。
@@ -557,7 +560,8 @@ NaCl では、有志が集まって隔週間隔で過去問を解いています
 ![kiri_hunter_quote.png]({{base}}{{site.baseurl}}/images/0042-FollowUpKirishimaRuby/kiri_hunter_quote.png)
 
 そして、コードを書くという遊びをめいいっぱい楽しんでいる人が、最終的には強いんじゃないのかな、と思います。
-<object width="560" height="315"><param name="movie" value="http://www.youtube.com/v/f9j4Qh5A3ys" /><embed src="http://www.youtube.com/v/f9j4Qh5A3ys" type="application/x-shockwave-flash" width="560" height="315" /></object>
+
+<iframe width="560" height="315" src="http://www.youtube.com/embed/f9j4Qh5A3ys" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 テキトーに遊んでたら Perfume がキビキビ動くようになったので、ちょっと自慢しておきますね（キビキビ動かすために実は GC を止めている……のは内緒）。
 ![kiri_mseki_quote.png]({{base}}{{site.baseurl}}/images/0042-FollowUpKirishimaRuby/kiri_mseki_quote.png)

--- a/articles/0047/_posts/2014-06-30-0047-RubyConfPH2014.md
+++ b/articles/0047/_posts/2014-06-30-0047-RubyConfPH2014.md
@@ -136,6 +136,6 @@ RubyConf.PH 2014 はフィリピンはマニラで行なわれました。
 ----
 
 最後に、オーガナイザの Christopher Rigor からのメッセージを動画でもらってきましたので、ご覧下さい。
-<object width="560" height="315"><param name="movie" value="http://www.youtube.com/v/lzmkQSZ9ftI" /><embed src="http://www.youtube.com/v/lzmkQSZ9ftI" type="application/x-shockwave-flash" width="560" height="315" /></object>
 
+<iframe width="560" height="315" src="http://www.youtube.com/embed/lzmkQSZ9ftI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 


### PR DESCRIPTION
Fix: #540

`<object>` `<param>` `<embed>`タグを使って記事中に埋め込もうとしたYouTubeが本番環境では全く表示されない状態になっていたのを修正しました。

変更前だと、例えば以下のような記述は
```
<object width="560" height="315"><param name="movie" value="http://www.youtube.com/v/lzmkQSZ9ftI" /><embed src="http://www.youtube.com/v/lzmkQSZ9ftI" type="application/x-shockwave-flash" width="560" height="315" /></object>
```
ローカル環境では、以下のようなHTMLとして変換されていました。ローカルでは埋め込み表示、再生ともに問題なく動いています。

```
<div class="ytp-cued-thumbnail-overlay" data-layer="4" style=""><div class="ytp-cued-thumbnail-overlay-image" style="background-image: url(&quot;https://i.ytimg.com/vi/lzmkQSZ9ftI/maxres2.jpg?sqp=-oaymwEoCIAKENAF8quKqQMcGADwAQH4Ad4EgAK4CIoCDAgAEAEYZSBhKFYwDw==&amp;rs=AOn4CLD7dGYTluFXgOCn9fXPuXwdHo-yTA&quot;);"></div><button class="ytp-large-play-button ytp-button ytp-large-play-button-red-bg" aria-label="再生" title="再生"><svg height="100%" version="1.1" viewBox="0 0 68 48" width="100%"><path class="ytp-large-play-button-bg" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z" fill="#f00"></path><path d="M 45,24 27,14 27,34" fill="#fff"></path></svg></button></div>
```

しかし本番環境ではこのようなHTMLになっていました。動作の再生も表示も何もされない状態でした。
```
<object width="560" height="315"><param name="movie" value="http://www.youtube.com/v/lzmkQSZ9ftI"><embed src="http://www.youtube.com/v/lzmkQSZ9ftI" type="application/x-shockwave-flash" width="560" height="315"></object>
```

この差分の要因は、ローカルでは本リポジトリを`bundle exec jekyll serve -I --future`で起動させるが、本番用には`bundle exec jekyll build`していることを踏まえると、jekyll側にコマンド間の挙動の差異があるのではないかと推測しています。



修正方針としては、
* 本当にjekyllのコマンドの挙動の結果なのかを調べ変換結果を揃える（そのあとにるびま側に修正が必要かもしれないし不要かもしれない）
* るびま側を変更してYouTubeの埋め込み表示をできないか検討する
      * `<object>`タグ等の使い方が間違っているのであればそれを正すとか、他のタグを使うなどが考えられる

という2点が浮かびました。このPRではるびま側を変更する方針で、具体的には`<iframe>`を利用することにしました。

理由としは2つあります。
* るびま全体を見てみたところ[KeebKaigi 2023 準公式参加記録](https://magazine.rubyist.net/articles/0063/0063-KeebKaigi2023Report.html)の記事中では、`<iframe>`を使って本番環境でもYouTubeの埋め込み表示が成功してること、以下のようにローカルと本番での挙動差異がないことから、`<iframe>`であれば記事中に使って問題ないと言えること
            
```
// ローカル環境
<div class="ytp-cued-thumbnail-overlay" data-layer="4" style=""><div class="ytp-cued-thumbnail-overlay-image" style="background-image: url(&quot;https://i.ytimg.com/vi_webp/Lk3-5ceJz4Y/maxresdefault.webp&quot;);"></div><button class="ytp-large-play-button ytp-button ytp-large-play-button-red-bg" aria-label="再生" title="再生"><svg height="100%" version="1.1" viewBox="0 0 68 48" width="100%"><path class="ytp-large-play-button-bg" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z" fill="#f00"></path><path d="M 45,24 27,14 27,34" fill="#fff"></path></svg></button></div>

// 本番環境
<div class="ytp-cued-thumbnail-overlay" data-layer="4" style=""><div class="ytp-cued-thumbnail-overlay-image" style="background-image: url(&quot;https://i.ytimg.com/vi_webp/Lk3-5ceJz4Y/maxresdefault.webp&quot;);"></div><button class="ytp-large-play-button ytp-button ytp-large-play-button-red-bg" aria-label="再生" title="再生"><svg height="100%" version="1.1" viewBox="0 0 68 48" width="100%"><path class="ytp-large-play-button-bg" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z" fill="#f00"></path><path d="M 45,24 27,14 27,34" fill="#fff"></path></svg></button></div>
```


* YouTubeの動画ページで「共有」 > 「埋め込む」と選択していくと、`<iframe>`を使ったHTMLが提示されるので、Google的には`<iframe/>`が前提となっていると考えられること


