### PR TITLE
pull request preview action の導入

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Fetch master
+        run: |
+          commits=${{ github.event.pull_request.commits }}
+          if [[ -n "$commits" ]]; then
+            # Prepare enough depth for diffs with master
+            git fetch --depth="$(( commits + 1 ))"
+          fi
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,33 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./_site/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,6 +34,9 @@ jobs:
         env:
           JEKYLL_ENV: production
 
+      - name: Remove unrelated images
+        run: git diff --name-only origin/master --relative=articles | ruby -nle 'puts $_[%r([0-9]{4}-[0-9]{2}-[0-9]{2}-([0-9]{4}-.+)\.md), 1]' | tr '\n' ',' | ruby -rfileutils -nle 'Dir.chdir("_site/images") { Dir.glob("*").each { FileUtils.rm_r(_1) if File.directory?(_1) && !$_.split(",").include?(_1) } }'
+
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,3 +31,5 @@ jobs:
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./_site/
+          deploy-repository: rubima/rubima-preview
+          token: ${{ secrets.PREVIEW_TOKEN }}


### PR DESCRIPTION
## About
PRごとにビルド結果をpreviewするアクションを導入してみます。
https://x.com/neko314_/status/1890755774680351004

モノとしては、 https://github.com/rossjrw/pr-preview-action を利用していて、まだ初期バージョンなのでちょっと荒削りながらだいたい動いてくれるんで、まあこれでいいんじゃないかな、と思ってます。

この pr-preview-action ってやつは、デフォルトでは同一リポジトリ内のどっかにプレビュー用のコンテンツをpushしてくれる、っていう単純な作りになってるんですが、GitHub Pages の場合は、1つのリポジトリには1つの名前(ドメイン名)しかつけられないので、それだとうまくいかないような気がしていて、そこで、rubima organization配下に、previewをデプロイするためだけの新たなリポジトリを作って、そちらにpushするようにしています。
という具合に、ちょっとだけ構成が無駄に複雑になってるところはあるんですが、そのぶんpreviewのゴチャゴチャでproductionのるびまが汚されたり、なんかの間違いでproductionのコンテンツをぶっ壊しちゃったり、みたいなことがなくなって、安全に運用できるはずです。

## Action詳細

さて、このアクションの処理の流れとしては、ざっくり以下のようになっています。

1. PRのソースをチェックアウトする
2. あとの工程でmasterからの差分を取得したいので、masterっぽいものをfetchする
3. Jekyll でコンテンツをビルドする
4. 容量節約のため、今回のPRで編集されたarticle以外のarticleに含まれる画像ファイルをビルド結果から削除する
5. rubima/rubima-preview の gh-pages にビルド結果をpushする
6. PR側にプレビューへのリンクをコメントする

このうち、2と4は少しトリッキーなのでちょっと説明すると、まず2のコードは https://github.com/actions/checkout/issues/438#issuecomment-1114110354 から拾ってきました。actions/checkout にデフォルトでこの機能が入ってないの不便だよなぁ、とは思いつつ、なんかだいぶアドホックな実装ではあるので、これに名前をつけたレベルのものを標準に取り込んでリリースするべきか、というと、ちょっと疑問かもしれません。とりあえずここではこれで動くといいな。

4はさらにアドホックで、writing_process.md とか script/checker.rb あたりから仕様を解読するにたぶんこんな感じだろうと推測してワンライナーを書き殴ってみたものになります。master から変更があったファイルたちの中から `articles/.*-号数-記事名.md` なファイル名を抜き出して、その `号数-記事名` 以外の画像ディレクトリを全て削除してて、article自体も消しといてもいいんだけど、そんなにデカくなさそうだからなんとなくそのまま残しちゃってます。
なんかとりあえず力技でてきとうにゴリッと解決しました、という感じだし、shell scriptぢからがよわすぎてRubyに逃げてたりして、なんかすいません……とか思いつつ、まず仕様の解釈がこれで合ってるのか疑問だし、たぶんもっとキレイに書けるんじゃないかと思うので、識者のツッコミをお待ちしています。

あと最後に、5の工程で別repoにpushするためにGHの personal access token が必要で、いったん僕のアカウントで rubima/rubima-preview への write のみを許可した fine-graind なPATを作って、そいつをこっちのrepoの Actions secrets に、`PREVIEW_TOKEN` っていう名前で登録してあります。PATの賞味期限は1年に設定してあるので、1年後になんかpreviewが見れなくなったらこいつのことを思い出してあげてください。

## デプロイ先のディレクトリ構成
rubima/rubima-preview のほうがどういう状態になるかなんですが、rubima側にPRが立つごとにこのアクションが走って、rubima/rubima-previewリポジトリの gh-pages ブランチにビルド結果がpushされます。複数PRの結果を並行して保持したいので上書きしちゃったらダメなわけで、ルートディレクトリ直下に
```
pr-1/
pr-2
...
```
みたいに、こっちのぷるりの番号に対応したサブディレクトリが掘られて、その中にpushされます。画像を全部こぴったら巨大になりすぎるのでPRで触ってる記事に関連してなさそうな画像は削除してからpushしてます、というのは上記のとおりです。
これは、特に削除する機能はどこにも実装されてないので、PRがマージされたりクローズされたりしても消えたりはしません。どうやって消すかはまた後日考えればいいかな、と。

## 制約(というかTODO)
rossjrw/pr-preview-action の現行バージョンにはひとつ残念な制約があって、READMEにも書かれてるんだけど、なんと、forkされたリポジトリからのPRに対してはpreviewが表示できません！
なにそれダメじゃん！って感じなんだけど、
> This Action does not currently support deploying previews for PRs from forks, but will do so in the upcoming v2.

とのことなので、v2のリリースを待つ。待っても出てこないようなら自力でなんとかする(同リポジトリの pull/6 から実装をこぴってきてなんとかする)。というTODOがあります。