### PR TITLE
【Fix Typo】RubyKaigiのスペースが空いていたので修正しました

### DIFF
--- a/articles/0065/_posts/2025-01-31-0065-KaigiOnRails2024Report.md
+++ b/articles/0065/_posts/2025-01-31-0065-KaigiOnRails2024Report.md
@@ -128,7 +128,7 @@ Kaigi on Rails 2024 には、オフラインで約 700 人が参加しました�
 ### [ほりゆう](https://x.com/yuki82511988)
 
 Kaigi on Rails オーガナイザーの 1 人。妻と Urawa.rb を主催しております。
-去年は Ruby Kaigi がきっかけで英語の勉強にたくさん挑戦できました。
+去年は RubyKaigi がきっかけで英語の勉強にたくさん挑戦できました。
 最近はもっぱら Cursor を触ってコーディングをしています。
 
 ### [nissyi](https://x.com/yuta_onishi_97)


### PR DESCRIPTION
書いた記事の中でTypoを見つけたので修正しました。