### PR TITLE
Fix#424 サイドバーのCSSレイアウト崩れを修正

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
             </div>
         </div>
         <hr>
-        <footer>
+        <footer class="footer">
             {% include footer.html %}
         </footer>
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,7 +25,7 @@
             </div>
         </div>
         <hr>
-        <footer>
+        <footer class="footer">
             {% include footer.html %}
         </footer>
     </div>

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,6 +1,4 @@
 body {
-    padding-top: 60px;
-    padding-bottom: 60px;
     font-family:-apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI","Noto Sans Japanese","ヒラギノ角ゴ ProN W3", Meiryo, sans-serif;
 }
 
@@ -23,7 +21,6 @@ body {
 .sidebar {
     background-color: #900;
     background: url(../images/rubima_logo_left.png) top no-repeat, url(../images/rubima_sidebar.png) bottom repeat-y;
-    position: absolute;
     top: 0em;
     left: 0px;
     width: 150px;
@@ -31,6 +28,7 @@ body {
     word-break: break-all;
     padding-top: 148px;
     padding-bottom: 5em;
+    float: left;
 }
 
 .sidebar h4 {
@@ -69,12 +67,12 @@ img {
 }
 
 .main {
-    margin-top: 0px;
-    margin-left: 150px;
+    margin-top: 60px;
     margin-right: 0.6em;
     padding: 0.0em;
     padding-top: 0em;
     padding-left: 0em;
+    overflow: hidden;
 }
 
 @media(max-width:600px) {

--- a/doc/writing_process.md
+++ b/doc/writing_process.md
@@ -1,6 +1,6 @@
 # るびまを手元で動かす
 
-Ruby 3.2+ が必要です。
+`.ruby-version`に記載されたRubyのバージョンが必要です。
 
 ```
 $ git clone git@github.com:rubima/magazine.rubyist.net.git


### PR DESCRIPTION
https://github.com/rubima/magazine.rubyist.net/issues/424 を修正しました。

- フッターを独立したコンテナにしました
- `sidebar`を`float: left`で左寄せ配置するようにしました
- `main`に`overflow: hidden`を指定することで、レイアウト崩れを防止しています
  - PCおよびタブレット環境でレイアウトが崩れないよう対応しています

下記の通り、記事本文がサイドバーより短い場合も、フッターが全文表示されるようになりました。

<img width="1703" height="205" alt="スクリーンショット 2025-11-08 2 21 42" src="https://github.com/user-attachments/assets/795387aa-f1c2-4568-8755-4bc2d59c2af5" />

### その他

ドキュメントの修正を行いました。
環境構築を行う際、`.ruby-version`に記載のあるRubyが必要です。
