### PR TITLE
Add missing post_url

### DIFF
--- a/editing_tools/template/index.md.erb
+++ b/editing_tools/template/index.md.erb
@@ -22,7 +22,7 @@ Ruby をはじめるにあたって必要な情報をご紹介します。本稿
 
 <% articles.each do |article| %>
 
-  ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [<%= article.title %>]({{base}}{% <%= article.path %> %})
+  ### ![title_mark.gif]({{base}}{{site.baseurl}}/images/title_mark.gif) [<%= article.title %>]({{base}}{% post_url <%= article.path %> %})
 
 書いた人：<%= article.author %>さん
 


### PR DESCRIPTION
各号の表紙を生成するのに利用しているediting_tools/template/index.md.erbの中で記事のリンクを生成していますが、`post_url`の参照がないために正しいリンクになっていなかったので修正しました。