### PR TITLE
るびま lint: リンク文字列末尾の疑問符・感嘆符では全角空白の警告を出さない

### DIFF
--- a/editing_tools/rubima-lint.rb
+++ b/editing_tools/rubima-lint.rb
@@ -221,7 +221,7 @@ class RubimaLint
 
   class QuestionExclamationInParagraphRule < LineRule
     def initialize
-      pattern = /#{Patterns::QUESTION_EXCLAMATION}(?!$)(?![　#{Patterns::QUESTION_EXCLAMATION}#{Patterns::CLOSE_BRACKETS}])/o
+      pattern = /#{Patterns::QUESTION_EXCLAMATION}(?!$)(?!\])(?![　#{Patterns::QUESTION_EXCLAMATION}#{Patterns::CLOSE_BRACKETS}])/o
       super('question_exclamation_in_paragraph', pattern, correctable: true, color_code: 31)
     end
 


### PR DESCRIPTION
るびま lint (`editing_tools/rubima-lint.rb`)の「疑問符・感嘆符の後には全角空白が必要です。」の warning の出力条件の修正です。

リンク文字列末尾に感嘆符(！or？)がある場合に、「疑問符・感嘆符の後には全角空白が必要です。」の warning の出力され、オートコレクトで不要な全角空白が追加されるので、リンク文字列末尾の感嘆符については warning を出力しないように変更しています。

- https://github.com/rubima/magazine.rubyist.net/pull/636#pullrequestreview-3633778779

### 再現手順
以下の sample.md のマークダウンファイルに対して `editing_tools/rubima-lint.rb` を実行する。

`$ bundle exec editing_tools/rubima-lint.rb sample.md`
```md
# sample.md
てすと！全角空白が必要なケース。
てすと！　全角空白あり。
[リンク文字列！](https://example.com)
```

### 期待する挙動
リンク文字列末尾に感嘆符(！)がある場合の4行目で「疑問符・感嘆符の後には全角空白が必要です。」の warning が出力されないこと。

```sh
$ bundle exec editing_tools/rubima-lint.rb sample.md
1 warning(s)
[Correctable] 疑問符・感嘆符の後には全角空白が必要です。 : 2行目 : てすと！全角空白が必要なケース。
```

### 実際の挙動
リンク文字列末尾に感嘆符(！)がある場合の4行目で「疑問符・感嘆符の後には全角空白が必要です。」の warning が出力されること。

```sh
$ bundle exec editing_tools/rubima-lint.rb sample.md
2 warning(s)
[Correctable] 疑問符・感嘆符の後には全角空白が必要です。 : 2行目 : てすと！全角空白が必要なケース。
[Correctable] 疑問符・感嘆符の後には全角空白が必要です。 : 4行目 : [リンク文字列！](https://example.com)
```
