### PR TITLE
Add missing character to short title for Issue 0065

### DIFF
--- a/articles/0065/_posts/2025-12-19-index.md
+++ b/articles/0065/_posts/2025-12-19-index.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Rubyist Magazine 0065 号
-short_title: 0065(2025-12)
+short_title: 0065号(2025-12)
 tags: 0065 index
 ---
 {% include base.html %}


### PR DESCRIPTION
別の作業中に0065号の`short_title`から「号」が抜けていることに気づきました。

Before:

<img width="192" height="164" alt="Screenshot 2026-01-26 16:37:30" src="https://github.com/user-attachments/assets/b52d736f-1fd2-4834-a87f-f1a16a197240" />

After:

<img width="192" height="164" alt="Screenshot 2026-01-26 16:36:17" src="https://github.com/user-attachments/assets/879ad4fe-5f00-421e-936d-7282e1d76f95" />
