### PR TITLE
リリース後の広報手順を追加する

### DIFF
--- a/doc/editing_process.md
+++ b/doc/editing_process.md
@@ -138,3 +138,11 @@ Show new pages since previous deploy
 ```
 
 このワークフローの現状の詳細は[`/.github/workflows/jekyll.yml`](/.github/workflows/jekyll.yml)で、実行されるスクリプトは[`script/show_new_pages.rb`](/script/show_new_pages.rb)で確認できます。
+
+## リリース後の広報
+新しい記事や新しい号数をリリースしたら、読者に知らせます。
+
+- 編集者自身のSNSアカウントなどでアナウンスしたり、
+- 日本Rubyの会のDiscordサーバーの`PROJECTS`カテゴリの`#rubima`チャンネルなどで依頼して、[@rubynokai](https://x.com/rubynokai)からアナウンスしてもらったり、
+
+しましょう。


### PR DESCRIPTION
[RegionalRubyKaigi レポート (93) ながらRuby会議01](https://magazine.rubyist.net/articles/0066/0066-NagaraRubyKaigi01Report.html)のリリース作業を参考に、リリース後の広報の手順を追加します。#653 の残作業のひとつです。