### PR TITLE
未リリースの号の記事をトップページに表示する

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,6 +15,7 @@ title: るびま
 {%     break %}
 {%   endif %}
 ## 最新記事
+次号にまとめられます。
 {%   break %}
 {% endfor %}
 

--- a/index.md
+++ b/index.md
@@ -9,6 +9,22 @@ title: るびま
 
 『Rubyist Magazine』、略して『るびま』は、Rubyist の Rubyist による、Rubyist とそうでない人のためのウェブ雑誌です。
 
+{% assign articles = site.posts | sort: "date" | reverse %}
+{% for post in articles %}
+{%   if post.tags contains "index" or post.tags contains "EditorsNote" %}
+{%     break %}
+{%   endif %}
+## 最新記事
+{%   break %}
+{% endfor %}
+
+{% for post in articles %}
+{%   if post.tags contains "index" or post.tags contains "EditorsNote" %}
+{%     break %}
+{%   endif %}
+- [{{ post.title }}]({{base}}{{ post.url }})
+{% endfor %}
+
 ## 最新号
 
 {% for post in site.tags.index limit: 1 %}


### PR DESCRIPTION
記事を日付順に並べ、最新のものから目次または編集後記までのものがあれば、最新記事として順に列挙します。

例えば0065号がリリースされている(目次あるいは編集後記が存在する)と、トップページが下記のようになります。

## 未リリースの号の記事がある場合
<img width="774" height="887" alt="Screenshot_2026-05-28_13-08-15" src="https://github.com/user-attachments/assets/df93a79a-7ebe-4e53-b1c1-48aeffb31f74" />

## 未リリースの号の記事がない場合
<img width="774" height="887" alt="Screenshot_2026-05-28_13-09-16" src="https://github.com/user-attachments/assets/26c3c2d8-505d-452f-9f52-766d223c6add" />
