### PR TITLE
サイトトップのバックナンバーの一覧での最新号の重複を解消する

### DIFF
--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ title: るびま
 
 ## バックナンバー
 
-{% for post in site.tags.index %}
+{% for post in site.tags.index offset: 1 %}
 
 - [{{ post.title }}]({{base}}{{ post.url }})
   {% endfor %}


### PR DESCRIPTION
Before (最新号とバックナンバーの最初に0065号がある)

<img width="574" height="362" alt="Screenshot 2026-05-31 at 15 16 31" src="https://github.com/user-attachments/assets/551339f8-2320-4359-869e-ac3e1e3e854b" />

after (バックナンバーが0064号から始まる)

<img width="574" height="362" alt="Screenshot 2026-05-31 at 15 16 10" src="https://github.com/user-attachments/assets/27962b3d-1c05-4be4-bb16-4b1e3d88b938" />
