### PR TITLE
トップページに表示する未リリース記事をcreated_onでソートする

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,8 +25,8 @@ title: るびま
 {%   if date > latest_volume_date %}
 ## 最新記事
 次号にまとめられます。
-{%     break %}
 {%   endif %}
+{%   break %}
 {% endfor %}
 
 {% for post in articles %}

--- a/index.md
+++ b/index.md
@@ -36,6 +36,8 @@ title: るびま
 {%   assign date = post.created_on | date: "%Y-%m-%d" %}
 {%   if date > latest_volume_date %}
 - [{{ post.title }}]({{base}}{{ post.url }})
+{%   else %}
+{%     break %}
 {%   endif %}
 {% endfor %}
 

--- a/index.md
+++ b/index.md
@@ -9,21 +9,34 @@ title: るびま
 
 『Rubyist Magazine』、略して『るびま』は、Rubyist の Rubyist による、Rubyist とそうでない人のためのウェブ雑誌です。
 
-{% assign articles = site.posts | sort: "date" | reverse %}
+{% comment %}
+最新号のリリース日を最新の表紙のdateとする。
+最近の記事はcreated_on順に並べ、最新号のリリース日よりも新しいものを「最新記事」に列挙する。
+古い記事にはcreated_onが設定されていないものがある。そのような記事は「最新記事」には含めない。
+{% endcomment %}
+{% assign latest_volume_date = site.tags.index | sort: "date" | map: "date" | last | date: "%Y-%m-%d" %}
+{% assign articles = site.posts | sort: "created_on" | reverse %}
+
 {% for post in articles %}
-{%   if post.tags contains "index" or post.tags contains "EditorsNote" %}
-{%     break %}
-{%   endif %}
+{%   unless post.created_on %}
+{%     continue %}
+{%   endunless %}
+{%   assign date = post.created_on | date: "%Y-%m-%d" %}
+{%   if date > latest_volume_date %}
 ## 最新記事
 次号にまとめられます。
-{%   break %}
+{%     break %}
+{%   endif %}
 {% endfor %}
 
 {% for post in articles %}
-{%   if post.tags contains "index" or post.tags contains "EditorsNote" %}
-{%     break %}
-{%   endif %}
+{%   unless post.created_on %}
+{%     continue %}
+{%   endunless %}
+{%   assign date = post.created_on | date: "%Y-%m-%d" %}
+{%   if date > latest_volume_date %}
 - [{{ post.title }}]({{base}}{{ post.url }})
+{%   endif %}
 {% endfor %}
 
 ## 最新号


### PR DESCRIPTION
トップページに表示する未リリースの号の記事を`date`プロパティでソートした場合、未リリースの号に含まれる記事の`date`プロパティが、最新のリリースの表紙や編集後記の`date`プロパティよりも過去の場合に、「最新記事」に表示されるべきなのに表示されない問題があることがわかった。ここで、記事、表紙、編集後記などの`date`プロパティはファイル名から抽出される。

このコミットでは、フロントマターの`created_on`プロパティで記事をソートするようにする。現状では表紙や編集後記のフロントマターには`created_on`プロパティは設定されていないので、最新号のリリース日は表紙の`date`プロパティから推定する。また、現状では、フロントマターに`created_on`プロパティが設定されていない記事は数年前のもののみのようなので、未リリース記事には含めない。

Closes #673